### PR TITLE
Add ApplicationUser and profile entities

### DIFF
--- a/Parkman/Domain/ApplicationDbContext.cs
+++ b/Parkman/Domain/ApplicationDbContext.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace Parkman.Domain;
+
+public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<PersonProfile> PersonProfiles => Set<PersonProfile>();
+    public DbSet<CompanyProfile> CompanyProfiles => Set<CompanyProfile>();
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+
+        builder.Entity<ApplicationUser>(user =>
+        {
+            user.HasOne(u => u.PersonProfile)
+                .WithOne(p => p.User)
+                .HasForeignKey<PersonProfile>(p => p.UserId);
+
+            user.HasOne(u => u.CompanyProfile)
+                .WithOne(c => c.User)
+                .HasForeignKey<CompanyProfile>(c => c.UserId);
+        });
+
+        builder.Entity<PersonProfile>(profile =>
+        {
+            profile.HasKey(p => p.UserId);
+            profile.Property(p => p.FirstName).IsRequired();
+            profile.Property(p => p.LastName).IsRequired();
+            profile.Property(p => p.DateOfBirth);
+        });
+
+        builder.Entity<CompanyProfile>(profile =>
+        {
+            profile.HasKey(p => p.UserId);
+            profile.Property(p => p.CompanyName).IsRequired();
+            profile.Property(p => p.Ico).IsRequired();
+            profile.Property(p => p.Dic).IsRequired();
+        });
+    }
+}

--- a/Parkman/Domain/ApplicationUser.cs
+++ b/Parkman/Domain/ApplicationUser.cs
@@ -1,0 +1,33 @@
+using System;
+using Microsoft.AspNetCore.Identity;
+
+namespace Parkman.Domain;
+
+public class ApplicationUser : IdentityUser
+{
+    public PersonProfile? PersonProfile { get; private set; }
+    public CompanyProfile? CompanyProfile { get; private set; }
+
+    public void SetPersonProfile(PersonProfile profile)
+    {
+        if (profile == null) throw new ArgumentNullException(nameof(profile));
+        if (CompanyProfile != null)
+        {
+            throw new InvalidOperationException("Cannot set person profile when company profile exists.");
+        }
+        PersonProfile = profile;
+        profile.SetUser(this);
+    }
+
+    public void SetCompanyProfile(CompanyProfile profile)
+    {
+        if (profile == null) throw new ArgumentNullException(nameof(profile));
+        if (PersonProfile != null)
+        {
+            throw new InvalidOperationException("Cannot set company profile when person profile exists.");
+        }
+        CompanyProfile = profile;
+        profile.SetUser(this);
+    }
+}
+

--- a/Parkman/Domain/CompanyProfile.cs
+++ b/Parkman/Domain/CompanyProfile.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Parkman.Domain;
+
+public class CompanyProfile
+{
+    public string UserId { get; private set; } = null!;
+    public ApplicationUser User { get; private set; } = null!;
+
+    public string CompanyName { get; private set; } = string.Empty;
+    public string Ico { get; private set; } = string.Empty;
+    public string Dic { get; private set; } = string.Empty;
+
+    private CompanyProfile() { }
+
+    public CompanyProfile(string companyName, string ico, string dic)
+    {
+        Update(companyName, ico, dic);
+    }
+
+    public void Update(string companyName, string ico, string dic)
+    {
+        if (string.IsNullOrWhiteSpace(companyName))
+            throw new ArgumentException("Company name is required", nameof(companyName));
+        if (string.IsNullOrWhiteSpace(ico))
+            throw new ArgumentException("ICO is required", nameof(ico));
+        if (string.IsNullOrWhiteSpace(dic))
+            throw new ArgumentException("DIC is required", nameof(dic));
+
+        CompanyName = companyName;
+        Ico = ico;
+        Dic = dic;
+    }
+
+    internal void SetUser(ApplicationUser user)
+    {
+        User = user;
+        UserId = user.Id;
+    }
+}

--- a/Parkman/Domain/PersonProfile.cs
+++ b/Parkman/Domain/PersonProfile.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Parkman.Domain;
+
+public class PersonProfile
+{
+    public string UserId { get; private set; } = null!;
+    public ApplicationUser User { get; private set; } = null!;
+
+    public string FirstName { get; private set; } = string.Empty;
+    public string LastName { get; private set; } = string.Empty;
+    public DateOnly DateOfBirth { get; private set; }
+
+    private PersonProfile() { }
+
+    public PersonProfile(string firstName, string lastName, DateOnly dateOfBirth)
+    {
+        Update(firstName, lastName, dateOfBirth);
+    }
+
+    public void Update(string firstName, string lastName, DateOnly dateOfBirth)
+    {
+        if (string.IsNullOrWhiteSpace(firstName))
+            throw new ArgumentException("First name is required", nameof(firstName));
+        if (string.IsNullOrWhiteSpace(lastName))
+            throw new ArgumentException("Last name is required", nameof(lastName));
+
+        FirstName = firstName;
+        LastName = lastName;
+        DateOfBirth = dateOfBirth;
+    }
+
+    internal void SetUser(ApplicationUser user)
+    {
+        User = user;
+        UserId = user.Id;
+    }
+}

--- a/Parkman/Parkman.csproj
+++ b/Parkman/Parkman.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add domain model classes for `ApplicationUser`, `PersonProfile`, and `CompanyProfile`
- add EF Core `ApplicationDbContext` with profile configuration
- reference EF Core and ASP.NET Identity packages

## Testing
- `dotnet build Parkman/Parkman.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b61de80b48326ab5512530aa2d12b