### PR TITLE
Configure SQL Server connection

### DIFF
--- a/Parkman/Parkman.csproj
+++ b/Parkman/Parkman.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
   </ItemGroup>
 

--- a/Parkman/Program.cs
+++ b/Parkman/Program.cs
@@ -1,6 +1,12 @@
+using Microsoft.EntityFrameworkCore;
+using Parkman.Domain;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle

--- a/Parkman/appsettings.Development.json
+++ b/Parkman/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=AETERNUM\\SQLEXPRESS;Database=FortifyDB;Trusted_Connection=True;Encrypt=False"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/Parkman/appsettings.json
+++ b/Parkman/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=AETERNUM\\SQLEXPRESS;Database=FortifyDB;Trusted_Connection=True;Encrypt=False"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- add Windows-auth connection string for SQL Server
- register ApplicationDbContext with SQL Server provider
- include SQL Server package

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b680e51b8832686af139df030ce83