### PR TITLE
Add extra fields to PersonProfile and CompanyProfile

### DIFF
--- a/Parkman/Domain/ApplicationDbContext.cs
+++ b/Parkman/Domain/ApplicationDbContext.cs
@@ -34,6 +34,8 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             profile.Property(p => p.FirstName).IsRequired();
             profile.Property(p => p.LastName).IsRequired();
             profile.Property(p => p.DateOfBirth);
+            profile.Property(p => p.PhoneNumber).IsRequired();
+            profile.Property(p => p.Address).IsRequired();
         });
 
         builder.Entity<CompanyProfile>(profile =>
@@ -42,6 +44,10 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             profile.Property(p => p.CompanyName).IsRequired();
             profile.Property(p => p.Ico).IsRequired();
             profile.Property(p => p.Dic).IsRequired();
+            profile.Property(p => p.ContactPersonName).IsRequired();
+            profile.Property(p => p.ContactEmail).IsRequired();
+            profile.Property(p => p.PhoneNumber).IsRequired();
+            profile.Property(p => p.BillingAddress).IsRequired();
         });
     }
 }

--- a/Parkman/Domain/CompanyProfile.cs
+++ b/Parkman/Domain/CompanyProfile.cs
@@ -10,15 +10,33 @@ public class CompanyProfile
     public string CompanyName { get; private set; } = string.Empty;
     public string Ico { get; private set; } = string.Empty;
     public string Dic { get; private set; } = string.Empty;
+    public string ContactPersonName { get; private set; } = string.Empty;
+    public string ContactEmail { get; private set; } = string.Empty;
+    public string PhoneNumber { get; private set; } = string.Empty;
+    public string BillingAddress { get; private set; } = string.Empty;
 
     private CompanyProfile() { }
 
-    public CompanyProfile(string companyName, string ico, string dic)
+    public CompanyProfile(
+        string companyName,
+        string ico,
+        string dic,
+        string contactPersonName,
+        string contactEmail,
+        string phoneNumber,
+        string billingAddress)
     {
-        Update(companyName, ico, dic);
+        Update(companyName, ico, dic, contactPersonName, contactEmail, phoneNumber, billingAddress);
     }
 
-    public void Update(string companyName, string ico, string dic)
+    public void Update(
+        string companyName,
+        string ico,
+        string dic,
+        string contactPersonName,
+        string contactEmail,
+        string phoneNumber,
+        string billingAddress)
     {
         if (string.IsNullOrWhiteSpace(companyName))
             throw new ArgumentException("Company name is required", nameof(companyName));
@@ -26,10 +44,22 @@ public class CompanyProfile
             throw new ArgumentException("ICO is required", nameof(ico));
         if (string.IsNullOrWhiteSpace(dic))
             throw new ArgumentException("DIC is required", nameof(dic));
+        if (string.IsNullOrWhiteSpace(contactPersonName))
+            throw new ArgumentException("Contact person name is required", nameof(contactPersonName));
+        if (string.IsNullOrWhiteSpace(contactEmail))
+            throw new ArgumentException("Contact email is required", nameof(contactEmail));
+        if (string.IsNullOrWhiteSpace(phoneNumber))
+            throw new ArgumentException("Phone number is required", nameof(phoneNumber));
+        if (string.IsNullOrWhiteSpace(billingAddress))
+            throw new ArgumentException("Billing address is required", nameof(billingAddress));
 
         CompanyName = companyName;
         Ico = ico;
         Dic = dic;
+        ContactPersonName = contactPersonName;
+        ContactEmail = contactEmail;
+        PhoneNumber = phoneNumber;
+        BillingAddress = billingAddress;
     }
 
     internal void SetUser(ApplicationUser user)

--- a/Parkman/Domain/PersonProfile.cs
+++ b/Parkman/Domain/PersonProfile.cs
@@ -9,25 +9,43 @@ public class PersonProfile
 
     public string FirstName { get; private set; } = string.Empty;
     public string LastName { get; private set; } = string.Empty;
-    public DateOnly DateOfBirth { get; private set; }
+    public DateOnly? DateOfBirth { get; private set; }
+    public string PhoneNumber { get; private set; } = string.Empty;
+    public string Address { get; private set; } = string.Empty;
 
     private PersonProfile() { }
 
-    public PersonProfile(string firstName, string lastName, DateOnly dateOfBirth)
+    public PersonProfile(
+        string firstName,
+        string lastName,
+        DateOnly? dateOfBirth,
+        string phoneNumber,
+        string address)
     {
-        Update(firstName, lastName, dateOfBirth);
+        Update(firstName, lastName, dateOfBirth, phoneNumber, address);
     }
 
-    public void Update(string firstName, string lastName, DateOnly dateOfBirth)
+    public void Update(
+        string firstName,
+        string lastName,
+        DateOnly? dateOfBirth,
+        string phoneNumber,
+        string address)
     {
         if (string.IsNullOrWhiteSpace(firstName))
             throw new ArgumentException("First name is required", nameof(firstName));
         if (string.IsNullOrWhiteSpace(lastName))
             throw new ArgumentException("Last name is required", nameof(lastName));
+        if (string.IsNullOrWhiteSpace(phoneNumber))
+            throw new ArgumentException("Phone number is required", nameof(phoneNumber));
+        if (string.IsNullOrWhiteSpace(address))
+            throw new ArgumentException("Address is required", nameof(address));
 
         FirstName = firstName;
         LastName = lastName;
         DateOfBirth = dateOfBirth;
+        PhoneNumber = phoneNumber;
+        Address = address;
     }
 
     internal void SetUser(ApplicationUser user)


### PR DESCRIPTION
## Summary
- extend `PersonProfile` to include phone number and address with optional date of birth
- extend `CompanyProfile` with contact details and billing address
- update EF Core model configuration for the new fields

## Testing
- `dotnet build Parkman.sln -v:q`

------
https://chatgpt.com/codex/tasks/task_e_687b6e9d85e08326abc929117ec9247c