### PR TITLE
Separate domain and infrastructure namespaces

### DIFF
--- a/Parkman/Domain/Entities/ApplicationUser.cs
+++ b/Parkman/Domain/Entities/ApplicationUser.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.AspNetCore.Identity;
 
-namespace Parkman.Domain;
+namespace Parkman.Domain.Entities;
 
 public class ApplicationUser : IdentityUser
 {

--- a/Parkman/Domain/Entities/CompanyProfile.cs
+++ b/Parkman/Domain/Entities/CompanyProfile.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Parkman.Domain;
+namespace Parkman.Domain.Entities;
 
 public class CompanyProfile
 {

--- a/Parkman/Domain/Entities/PersonProfile.cs
+++ b/Parkman/Domain/Entities/PersonProfile.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Parkman.Domain;
+namespace Parkman.Domain.Entities;
 
 public class PersonProfile
 {

--- a/Parkman/Domain/Entities/Vehicle.cs
+++ b/Parkman/Domain/Entities/Vehicle.cs
@@ -1,6 +1,8 @@
 using System;
 
-namespace Parkman.Domain;
+using Parkman.Domain.Enums;
+
+namespace Parkman.Domain.Entities;
 
 public class Vehicle
 {

--- a/Parkman/Domain/Enums/VehicleBrand.cs
+++ b/Parkman/Domain/Enums/VehicleBrand.cs
@@ -1,4 +1,4 @@
-﻿namespace Parkman.Domain
+﻿namespace Parkman.Domain.Enums
 {
     public enum VehicleBrand
     {

--- a/Parkman/Domain/Enums/VehiclePropulsionType.cs
+++ b/Parkman/Domain/Enums/VehiclePropulsionType.cs
@@ -1,4 +1,4 @@
-namespace Parkman.Domain;
+namespace Parkman.Domain.Enums;
 
 public enum VehiclePropulsionType
 {

--- a/Parkman/Domain/Enums/VehicleType.cs
+++ b/Parkman/Domain/Enums/VehicleType.cs
@@ -1,4 +1,4 @@
-namespace Parkman.Domain;
+namespace Parkman.Domain.Enums;
 
 public enum VehicleType
 {

--- a/Parkman/Infrastructure/ApplicationDbContext.cs
+++ b/Parkman/Infrastructure/ApplicationDbContext.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
-namespace Parkman.Domain;
+using Parkman.Domain.Entities;
+
+namespace Parkman.Infrastructure;
 
 public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 {

--- a/Parkman/Program.cs
+++ b/Parkman/Program.cs
@@ -1,5 +1,5 @@
 using Microsoft.EntityFrameworkCore;
-using Parkman.Domain;
+using Parkman.Infrastructure;
 
 var builder = WebApplication.CreateBuilder(args);
 


### PR DESCRIPTION
## Summary
- move ApplicationDbContext into Infrastructure namespace
- group entities and enums into Domain sub-namespaces
- update Program.cs to use Infrastructure namespace

## Testing
- `dotnet build Parkman.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687b7e3b87e083269e0fd5bcb65dc351