### PR TITLE
Add parking spot enums

### DIFF
--- a/Parkman/Domain/Entities/ParkingSpot.cs
+++ b/Parkman/Domain/Entities/ParkingSpot.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Parkman.Domain.Enums;
 
 namespace Parkman.Domain.Entities;
 
@@ -9,6 +10,10 @@ public class ParkingSpot
 
     public string Identifier { get; private set; } = string.Empty;
 
+    public ParkingSpotType Type { get; private set; }
+    public ParkingSpotAccessibility Accessibility { get; private set; }
+    public ParkingSpotAllowedPropulsionType AllowedPropulsion { get; private set; }
+
     public int ParkingLotId { get; private set; }
     public ParkingLot ParkingLot { get; private set; } = null!;
 
@@ -16,17 +21,28 @@ public class ParkingSpot
 
     private ParkingSpot() { }
 
-    public ParkingSpot(string identifier)
+    public ParkingSpot(
+        string identifier,
+        ParkingSpotType type,
+        ParkingSpotAccessibility accessibility,
+        ParkingSpotAllowedPropulsionType allowedPropulsion)
     {
-        Update(identifier);
+        Update(identifier, type, accessibility, allowedPropulsion);
     }
 
-    public void Update(string identifier)
+    public void Update(
+        string identifier,
+        ParkingSpotType type,
+        ParkingSpotAccessibility accessibility,
+        ParkingSpotAllowedPropulsionType allowedPropulsion)
     {
         if (string.IsNullOrWhiteSpace(identifier))
             throw new ArgumentException("Identifier is required", nameof(identifier));
 
         Identifier = identifier;
+        Type = type;
+        Accessibility = accessibility;
+        AllowedPropulsion = allowedPropulsion;
     }
 
     internal void SetParkingLot(ParkingLot lot)

--- a/Parkman/Domain/Enums/ParkingSpotAccessibility.cs
+++ b/Parkman/Domain/Enums/ParkingSpotAccessibility.cs
@@ -1,0 +1,8 @@
+namespace Parkman.Domain.Enums;
+
+public enum ParkingSpotAccessibility
+{
+    None,
+    Handicapped,
+    Family
+}

--- a/Parkman/Domain/Enums/ParkingSpotAllowedPropulsionType.cs
+++ b/Parkman/Domain/Enums/ParkingSpotAllowedPropulsionType.cs
@@ -1,0 +1,13 @@
+namespace Parkman.Domain.Enums;
+
+public enum ParkingSpotAllowedPropulsionType
+{
+    Any,
+    Gasoline,
+    Diesel,
+    Electric,
+    Hybrid,
+    Lpg,
+    NaturalGas,
+    Hydrogen
+}

--- a/Parkman/Domain/Enums/ParkingSpotType.cs
+++ b/Parkman/Domain/Enums/ParkingSpotType.cs
@@ -1,0 +1,11 @@
+namespace Parkman.Domain.Enums;
+
+public enum ParkingSpotType
+{
+    Regular,
+    ElectricOnly,
+    Covered,
+    Uncovered,
+    Compact,
+    Large
+}

--- a/Parkman/Infrastructure/ApplicationDbContext.cs
+++ b/Parkman/Infrastructure/ApplicationDbContext.cs
@@ -93,6 +93,9 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
         {
             spot.HasKey(s => s.Id);
             spot.Property(s => s.Identifier).IsRequired();
+            spot.Property(s => s.Type).IsRequired();
+            spot.Property(s => s.Accessibility).IsRequired();
+            spot.Property(s => s.AllowedPropulsion).IsRequired();
             spot.HasMany(s => s.Reservations)
                 .WithOne(r => r.ParkingSpot)
                 .HasForeignKey(r => r.ParkingSpotId);


### PR DESCRIPTION
## Summary
- create enums for parking spot type, accessibility and allowed propulsion
- link these enums to `ParkingSpot` entity
- update EF configuration

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b92344b288326b79c95d9b49fc648