### PR TITLE
Create join entity for profile reservations

### DIFF
--- a/Parkman/Domain/Entities/PersonProfile.cs
+++ b/Parkman/Domain/Entities/PersonProfile.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Parkman.Domain.Entities;
 
@@ -14,6 +15,8 @@ public class PersonProfile
     public string Address { get; private set; } = string.Empty;
 
     public Vehicle? Vehicle { get; private set; }
+
+    public List<ProfileReservation> ProfileReservations { get; } = new();
 
     public string? CompanyProfileUserId { get; private set; }
     public CompanyProfile? CompanyProfile { get; private set; }
@@ -66,6 +69,14 @@ public class PersonProfile
         }
         Vehicle = vehicle;
         vehicle.SetPersonProfile(this);
+    }
+
+    internal void AddReservation(Reservation reservation)
+    {
+        if (reservation == null) throw new ArgumentNullException(nameof(reservation));
+        var link = new ProfileReservation(this, reservation);
+        ProfileReservations.Add(link);
+        reservation.AddProfileReservation(link);
     }
 
     internal void SetUser(ApplicationUser user)

--- a/Parkman/Domain/Entities/ProfileReservation.cs
+++ b/Parkman/Domain/Entities/ProfileReservation.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Parkman.Domain.Entities;
+
+public class ProfileReservation
+{
+    public string PersonProfileUserId { get; private set; } = null!;
+    public PersonProfile PersonProfile { get; private set; } = null!;
+
+    public int ReservationId { get; private set; }
+    public Reservation Reservation { get; private set; } = null!;
+
+    private ProfileReservation() { }
+
+    internal ProfileReservation(PersonProfile profile, Reservation reservation)
+    {
+        SetPersonProfile(profile);
+        SetReservation(reservation);
+    }
+
+    internal void SetPersonProfile(PersonProfile profile)
+    {
+        PersonProfile = profile ?? throw new ArgumentNullException(nameof(profile));
+        PersonProfileUserId = profile.UserId;
+    }
+
+    internal void SetReservation(Reservation reservation)
+    {
+        Reservation = reservation ?? throw new ArgumentNullException(nameof(reservation));
+        ReservationId = reservation.Id;
+    }
+}

--- a/Parkman/Domain/Entities/Reservation.cs
+++ b/Parkman/Domain/Entities/Reservation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Parkman.Domain.Entities;
 
@@ -11,6 +12,8 @@ public class Reservation
 
     public int ParkingSpotId { get; private set; }
     public ParkingSpot ParkingSpot { get; private set; } = null!;
+
+    public List<ProfileReservation> ProfileReservations { get; } = new();
 
     private Reservation() { }
 
@@ -32,5 +35,11 @@ public class Reservation
     {
         ParkingSpot = spot;
         ParkingSpotId = spot.Id;
+    }
+
+    internal void AddProfileReservation(ProfileReservation link)
+    {
+        if (link == null) throw new ArgumentNullException(nameof(link));
+        ProfileReservations.Add(link);
     }
 }

--- a/Parkman/Infrastructure/ApplicationDbContext.cs
+++ b/Parkman/Infrastructure/ApplicationDbContext.cs
@@ -18,6 +18,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     public DbSet<ParkingLot> ParkingLots => Set<ParkingLot>();
     public DbSet<ParkingSpot> ParkingSpots => Set<ParkingSpot>();
     public DbSet<Reservation> Reservations => Set<Reservation>();
+    public DbSet<ProfileReservation> ProfileReservations => Set<ProfileReservation>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -106,6 +107,17 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             reservation.HasKey(r => r.Id);
             reservation.Property(r => r.StartTime).IsRequired();
             reservation.Property(r => r.EndTime).IsRequired();
+            reservation.HasMany(r => r.ProfileReservations)
+                .WithOne(pr => pr.Reservation)
+                .HasForeignKey(pr => pr.ReservationId);
+        });
+
+        builder.Entity<ProfileReservation>(pr =>
+        {
+            pr.HasKey(x => new { x.PersonProfileUserId, x.ReservationId });
+            pr.HasOne(x => x.PersonProfile)
+                .WithMany(p => p.ProfileReservations)
+                .HasForeignKey(x => x.PersonProfileUserId);
         });
     }
 }


### PR DESCRIPTION
## Summary
- add a new `ProfileReservation` entity
- connect reservations to profiles via `ProfileReservation`
- configure EF Core mappings for the join entity

## Testing
- `dotnet build Parkman/Parkman.csproj`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687cbe7eb06c8326946dd8defbdf9b88