### PR TITLE
Add company reservation link entity

### DIFF
--- a/Parkman/Domain/Entities/CompanyProfile.cs
+++ b/Parkman/Domain/Entities/CompanyProfile.cs
@@ -17,6 +17,7 @@ public class CompanyProfile
 
     public List<Vehicle> Vehicles { get; } = new();
     public List<PersonProfile> Members { get; } = new();
+    public List<CompanyReservation> CompanyReservations { get; } = new();
 
     private CompanyProfile() { }
 
@@ -77,6 +78,14 @@ public class CompanyProfile
         if (personProfile == null) throw new ArgumentNullException(nameof(personProfile));
         Members.Add(personProfile);
         personProfile.SetCompanyProfile(this);
+    }
+
+    internal void AddReservation(Reservation reservation)
+    {
+        if (reservation == null) throw new ArgumentNullException(nameof(reservation));
+        var link = new CompanyReservation(this, reservation);
+        CompanyReservations.Add(link);
+        reservation.AddCompanyReservation(link);
     }
 
     internal void SetUser(ApplicationUser user)

--- a/Parkman/Domain/Entities/CompanyReservation.cs
+++ b/Parkman/Domain/Entities/CompanyReservation.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Parkman.Domain.Entities;
+
+public class CompanyReservation
+{
+    public string CompanyProfileUserId { get; private set; } = null!;
+    public CompanyProfile CompanyProfile { get; private set; } = null!;
+
+    public int ReservationId { get; private set; }
+    public Reservation Reservation { get; private set; } = null!;
+
+    private CompanyReservation() { }
+
+    internal CompanyReservation(CompanyProfile companyProfile, Reservation reservation)
+    {
+        SetCompanyProfile(companyProfile);
+        SetReservation(reservation);
+    }
+
+    internal void SetCompanyProfile(CompanyProfile companyProfile)
+    {
+        CompanyProfile = companyProfile ?? throw new ArgumentNullException(nameof(companyProfile));
+        CompanyProfileUserId = companyProfile.UserId;
+    }
+
+    internal void SetReservation(Reservation reservation)
+    {
+        Reservation = reservation ?? throw new ArgumentNullException(nameof(reservation));
+        ReservationId = reservation.Id;
+    }
+}

--- a/Parkman/Domain/Entities/Reservation.cs
+++ b/Parkman/Domain/Entities/Reservation.cs
@@ -14,6 +14,7 @@ public class Reservation
     public ParkingSpot ParkingSpot { get; private set; } = null!;
 
     public List<ProfileReservation> ProfileReservations { get; } = new();
+    public List<CompanyReservation> CompanyReservations { get; } = new();
 
     private Reservation() { }
 
@@ -41,5 +42,11 @@ public class Reservation
     {
         if (link == null) throw new ArgumentNullException(nameof(link));
         ProfileReservations.Add(link);
+    }
+
+    internal void AddCompanyReservation(CompanyReservation link)
+    {
+        if (link == null) throw new ArgumentNullException(nameof(link));
+        CompanyReservations.Add(link);
     }
 }

--- a/Parkman/Infrastructure/ApplicationDbContext.cs
+++ b/Parkman/Infrastructure/ApplicationDbContext.cs
@@ -19,6 +19,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     public DbSet<ParkingSpot> ParkingSpots => Set<ParkingSpot>();
     public DbSet<Reservation> Reservations => Set<Reservation>();
     public DbSet<ProfileReservation> ProfileReservations => Set<ProfileReservation>();
+    public DbSet<CompanyReservation> CompanyReservations => Set<CompanyReservation>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -64,6 +65,9 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             profile.HasMany(p => p.Members)
                 .WithOne(m => m.CompanyProfile)
                 .HasForeignKey(m => m.CompanyProfileUserId);
+            profile.HasMany(p => p.CompanyReservations)
+                .WithOne(cr => cr.CompanyProfile)
+                .HasForeignKey(cr => cr.CompanyProfileUserId);
         });
 
         builder.Entity<Vehicle>(vehicle =>
@@ -110,6 +114,9 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             reservation.HasMany(r => r.ProfileReservations)
                 .WithOne(pr => pr.Reservation)
                 .HasForeignKey(pr => pr.ReservationId);
+            reservation.HasMany(r => r.CompanyReservations)
+                .WithOne(cr => cr.Reservation)
+                .HasForeignKey(cr => cr.ReservationId);
         });
 
         builder.Entity<ProfileReservation>(pr =>
@@ -118,6 +125,14 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             pr.HasOne(x => x.PersonProfile)
                 .WithMany(p => p.ProfileReservations)
                 .HasForeignKey(x => x.PersonProfileUserId);
+        });
+
+        builder.Entity<CompanyReservation>(cr =>
+        {
+            cr.HasKey(x => new { x.CompanyProfileUserId, x.ReservationId });
+            cr.HasOne(x => x.CompanyProfile)
+                .WithMany(c => c.CompanyReservations)
+                .HasForeignKey(x => x.CompanyProfileUserId);
         });
     }
 }


### PR DESCRIPTION
## Summary
- link company profiles to reservations via new `CompanyReservation`
- track company reservations in `CompanyProfile`, `Reservation`, and EF model

## Testing
- `dotnet build Parkman.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687cc09368148326a66d16521e91d8a6