### PR TITLE
Use read-only collections for navigations

### DIFF
--- a/Parkman/Domain/Entities/CompanyProfile.cs
+++ b/Parkman/Domain/Entities/CompanyProfile.cs
@@ -15,9 +15,12 @@ public class CompanyProfile
     public string PhoneNumber { get; private set; } = string.Empty;
     public string BillingAddress { get; private set; } = string.Empty;
 
-    public List<Vehicle> Vehicles { get; } = new();
-    public List<PersonProfile> Members { get; } = new();
-    public List<CompanyReservation> CompanyReservations { get; } = new();
+    private readonly List<Vehicle> _vehicles = new();
+    public IReadOnlyCollection<Vehicle> Vehicles => _vehicles;
+    private readonly List<PersonProfile> _members = new();
+    public IReadOnlyCollection<PersonProfile> Members => _members;
+    private readonly List<CompanyReservation> _companyReservations = new();
+    public IReadOnlyCollection<CompanyReservation> CompanyReservations => _companyReservations;
 
     private CompanyProfile() { }
 
@@ -69,14 +72,14 @@ public class CompanyProfile
     internal void AddVehicle(Vehicle vehicle)
     {
         if (vehicle == null) throw new ArgumentNullException(nameof(vehicle));
-        Vehicles.Add(vehicle);
+        _vehicles.Add(vehicle);
         vehicle.SetCompanyProfile(this);
     }
 
     internal void AddMember(PersonProfile personProfile)
     {
         if (personProfile == null) throw new ArgumentNullException(nameof(personProfile));
-        Members.Add(personProfile);
+        _members.Add(personProfile);
         personProfile.SetCompanyProfile(this);
     }
 
@@ -84,7 +87,7 @@ public class CompanyProfile
     {
         if (reservation == null) throw new ArgumentNullException(nameof(reservation));
         var link = new CompanyReservation(this, reservation);
-        CompanyReservations.Add(link);
+        _companyReservations.Add(link);
         reservation.AddCompanyReservation(link);
     }
 

--- a/Parkman/Domain/Entities/ParkingLot.cs
+++ b/Parkman/Domain/Entities/ParkingLot.cs
@@ -10,7 +10,8 @@ public class ParkingLot
     public string Name { get; private set; } = string.Empty;
     public string Address { get; private set; } = string.Empty;
 
-    public List<ParkingSpot> Spots { get; } = new();
+    private readonly List<ParkingSpot> _spots = new();
+    public IReadOnlyCollection<ParkingSpot> Spots => _spots;
 
     private ParkingLot() { }
 
@@ -33,7 +34,7 @@ public class ParkingLot
     internal void AddSpot(ParkingSpot spot)
     {
         if (spot == null) throw new ArgumentNullException(nameof(spot));
-        Spots.Add(spot);
+        _spots.Add(spot);
         spot.SetParkingLot(this);
     }
 }

--- a/Parkman/Domain/Entities/ParkingSpot.cs
+++ b/Parkman/Domain/Entities/ParkingSpot.cs
@@ -17,7 +17,8 @@ public class ParkingSpot
     public int ParkingLotId { get; private set; }
     public ParkingLot ParkingLot { get; private set; } = null!;
 
-    public List<Reservation> Reservations { get; } = new();
+    private readonly List<Reservation> _reservations = new();
+    public IReadOnlyCollection<Reservation> Reservations => _reservations;
 
     private ParkingSpot() { }
 
@@ -54,7 +55,7 @@ public class ParkingSpot
     internal void AddReservation(Reservation reservation)
     {
         if (reservation == null) throw new ArgumentNullException(nameof(reservation));
-        Reservations.Add(reservation);
+        _reservations.Add(reservation);
         reservation.SetParkingSpot(this);
     }
 }

--- a/Parkman/Domain/Entities/PersonProfile.cs
+++ b/Parkman/Domain/Entities/PersonProfile.cs
@@ -16,7 +16,8 @@ public class PersonProfile
 
     public Vehicle? Vehicle { get; private set; }
 
-    public List<ProfileReservation> ProfileReservations { get; } = new();
+    private readonly List<ProfileReservation> _profileReservations = new();
+    public IReadOnlyCollection<ProfileReservation> ProfileReservations => _profileReservations;
 
     public string? CompanyProfileUserId { get; private set; }
     public CompanyProfile? CompanyProfile { get; private set; }
@@ -75,7 +76,7 @@ public class PersonProfile
     {
         if (reservation == null) throw new ArgumentNullException(nameof(reservation));
         var link = new ProfileReservation(this, reservation);
-        ProfileReservations.Add(link);
+        _profileReservations.Add(link);
         reservation.AddProfileReservation(link);
     }
 

--- a/Parkman/Domain/Entities/Reservation.cs
+++ b/Parkman/Domain/Entities/Reservation.cs
@@ -13,8 +13,10 @@ public class Reservation
     public int ParkingSpotId { get; private set; }
     public ParkingSpot ParkingSpot { get; private set; } = null!;
 
-    public List<ProfileReservation> ProfileReservations { get; } = new();
-    public List<CompanyReservation> CompanyReservations { get; } = new();
+    private readonly List<ProfileReservation> _profileReservations = new();
+    public IReadOnlyCollection<ProfileReservation> ProfileReservations => _profileReservations;
+    private readonly List<CompanyReservation> _companyReservations = new();
+    public IReadOnlyCollection<CompanyReservation> CompanyReservations => _companyReservations;
 
     private Reservation() { }
 
@@ -41,12 +43,12 @@ public class Reservation
     internal void AddProfileReservation(ProfileReservation link)
     {
         if (link == null) throw new ArgumentNullException(nameof(link));
-        ProfileReservations.Add(link);
+        _profileReservations.Add(link);
     }
 
     internal void AddCompanyReservation(CompanyReservation link)
     {
         if (link == null) throw new ArgumentNullException(nameof(link));
-        CompanyReservations.Add(link);
+        _companyReservations.Add(link);
     }
 }

--- a/Parkman/Infrastructure/ApplicationDbContext.cs
+++ b/Parkman/Infrastructure/ApplicationDbContext.cs
@@ -47,6 +47,9 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             profile.HasOne(p => p.CompanyProfile)
                 .WithMany(c => c.Members)
                 .HasForeignKey(p => p.CompanyProfileUserId);
+            profile.Navigation(p => p.ProfileReservations)
+                .HasField("_profileReservations")
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
         });
 
         builder.Entity<CompanyProfile>(profile =>
@@ -62,12 +65,21 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             profile.HasMany(p => p.Vehicles)
                 .WithOne(v => v.CompanyProfile)
                 .HasForeignKey(v => v.CompanyProfileUserId);
+            profile.Navigation(p => p.Vehicles)
+                .HasField("_vehicles")
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
             profile.HasMany(p => p.Members)
                 .WithOne(m => m.CompanyProfile)
                 .HasForeignKey(m => m.CompanyProfileUserId);
+            profile.Navigation(p => p.Members)
+                .HasField("_members")
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
             profile.HasMany(p => p.CompanyReservations)
                 .WithOne(cr => cr.CompanyProfile)
                 .HasForeignKey(cr => cr.CompanyProfileUserId);
+            profile.Navigation(p => p.CompanyReservations)
+                .HasField("_companyReservations")
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
         });
 
         builder.Entity<Vehicle>(vehicle =>
@@ -92,6 +104,9 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             lot.HasMany(l => l.Spots)
                 .WithOne(s => s.ParkingLot)
                 .HasForeignKey(s => s.ParkingLotId);
+            lot.Navigation(l => l.Spots)
+                .HasField("_spots")
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
         });
 
         builder.Entity<ParkingSpot>(spot =>
@@ -104,6 +119,9 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             spot.HasMany(s => s.Reservations)
                 .WithOne(r => r.ParkingSpot)
                 .HasForeignKey(r => r.ParkingSpotId);
+            spot.Navigation(s => s.Reservations)
+                .HasField("_reservations")
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
         });
 
         builder.Entity<Reservation>(reservation =>
@@ -114,9 +132,15 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             reservation.HasMany(r => r.ProfileReservations)
                 .WithOne(pr => pr.Reservation)
                 .HasForeignKey(pr => pr.ReservationId);
+            reservation.Navigation(r => r.ProfileReservations)
+                .HasField("_profileReservations")
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
             reservation.HasMany(r => r.CompanyReservations)
                 .WithOne(cr => cr.Reservation)
                 .HasForeignKey(cr => cr.ReservationId);
+            reservation.Navigation(r => r.CompanyReservations)
+                .HasField("_companyReservations")
+                .UsePropertyAccessMode(PropertyAccessMode.Field);
         });
 
         builder.Entity<ProfileReservation>(pr =>


### PR DESCRIPTION
## Summary
- expose collections like `Spots` and `Vehicles` as `IReadOnlyCollection`
- keep private backing lists for mutability
- map navigation properties to backing fields in EF Core

## Testing
- `dotnet build Parkman/Parkman.csproj -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_687cc58bece883269831f8795097406f