### PR TITLE
Add overlap check for reservations

### DIFF
--- a/Parkman.Tests/Domain/ParkingSpotTests.cs
+++ b/Parkman.Tests/Domain/ParkingSpotTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Parkman.Domain.Entities;
+using Parkman.Domain.Enums;
+using Xunit;
+
+namespace Parkman.Tests.Domain;
+
+public class ParkingSpotTests
+{
+    [Fact]
+    public void Adding_overlapping_reservation_should_throw()
+    {
+        var spot = new ParkingSpot("A1", ParkingSpotType.Regular, ParkingSpotAccessibility.None, ParkingSpotAllowedPropulsionType.Any);
+        var first = new Reservation(DateTime.Parse("2024-01-01T10:00:00"), DateTime.Parse("2024-01-01T11:00:00"));
+        spot.AddReservation(first);
+
+        var overlapping = new Reservation(DateTime.Parse("2024-01-01T10:30:00"), DateTime.Parse("2024-01-01T11:30:00"));
+
+        Assert.Throws<InvalidOperationException>(() => spot.AddReservation(overlapping));
+    }
+
+    [Fact]
+    public void Non_overlapping_reservation_should_be_added()
+    {
+        var spot = new ParkingSpot("A1", ParkingSpotType.Regular, ParkingSpotAccessibility.None, ParkingSpotAllowedPropulsionType.Any);
+        var first = new Reservation(DateTime.Parse("2024-01-01T10:00:00"), DateTime.Parse("2024-01-01T11:00:00"));
+        spot.AddReservation(first);
+
+        var second = new Reservation(DateTime.Parse("2024-01-01T11:00:00"), DateTime.Parse("2024-01-01T12:00:00"));
+        spot.AddReservation(second);
+
+        Assert.Equal(2, spot.Reservations.Count);
+    }
+}

--- a/Parkman.Tests/Parkman.Tests.csproj
+++ b/Parkman.Tests/Parkman.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="coverlet.collector" Version="6.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Parkman\Parkman.csproj" />
+  </ItemGroup>
+</Project>

--- a/Parkman.sln
+++ b/Parkman.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 17.14.36301.6 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Parkman", "Parkman\Parkman.csproj", "{F2AEF9F1-0E4A-44A6-B09B-E5AC64EA3487}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Parkman.Tests", "Parkman.Tests\Parkman.Tests.csproj", "{3DABF74D-8E26-4AD7-84E4-AB872D0EFD6D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F2AEF9F1-0E4A-44A6-B09B-E5AC64EA3487}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F2AEF9F1-0E4A-44A6-B09B-E5AC64EA3487}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F2AEF9F1-0E4A-44A6-B09B-E5AC64EA3487}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F2AEF9F1-0E4A-44A6-B09B-E5AC64EA3487}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{F2AEF9F1-0E4A-44A6-B09B-E5AC64EA3487}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{F2AEF9F1-0E4A-44A6-B09B-E5AC64EA3487}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{F2AEF9F1-0E4A-44A6-B09B-E5AC64EA3487}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{F2AEF9F1-0E4A-44A6-B09B-E5AC64EA3487}.Release|Any CPU.Build.0 = Release|Any CPU
+{3DABF74D-8E26-4AD7-84E4-AB872D0EFD6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{3DABF74D-8E26-4AD7-84E4-AB872D0EFD6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{3DABF74D-8E26-4AD7-84E4-AB872D0EFD6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{3DABF74D-8E26-4AD7-84E4-AB872D0EFD6D}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Parkman/Domain/Entities/ParkingSpot.cs
+++ b/Parkman/Domain/Entities/ParkingSpot.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Parkman.Domain.Enums;
 
 namespace Parkman.Domain.Entities;
@@ -55,7 +56,20 @@ public class ParkingSpot
     internal void AddReservation(Reservation reservation)
     {
         if (reservation == null) throw new ArgumentNullException(nameof(reservation));
+        if (HasReservationConflict(reservation.StartTime, reservation.EndTime))
+        {
+            throw new InvalidOperationException("Reservation overlaps with an existing reservation.");
+        }
+
         _reservations.Add(reservation);
         reservation.SetParkingSpot(this);
+    }
+
+    public bool HasReservationConflict(DateTime startTime, DateTime endTime)
+    {
+        if (endTime <= startTime)
+            throw new ArgumentException("End time must be after start time", nameof(endTime));
+
+        return _reservations.Any(r => r.StartTime < endTime && startTime < r.EndTime);
     }
 }


### PR DESCRIPTION
## Summary
- prevent overlapping reservations by adding a conflict check in `ParkingSpot`
- create xUnit test project and add tests for overlap logic

## Testing
- `dotnet test Parkman.Tests/Parkman.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cc7c6b0cc83268b9c27428d12b42a