### PR TITLE
Fix BOM in VehicleBrand enum

### DIFF
--- a/Parkman/Domain/Enums/VehicleBrand.cs
+++ b/Parkman/Domain/Enums/VehicleBrand.cs
@@ -1,4 +1,4 @@
-﻿namespace Parkman.Domain.Enums
+namespace Parkman.Domain.Enums
 {
     public enum VehicleBrand
     {


### PR DESCRIPTION
## Summary
- remove leading BOM from `VehicleBrand.cs`

## Testing
- `dotnet test Parkman.Tests/Parkman.Tests.csproj` *(fails: 'AddReservation' not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ccc61f0508326b73170b7206ab207