### PR TITLE
Add parking spot label support

### DIFF
--- a/Parkman.Tests/Domain/ParkingSpotTests.cs
+++ b/Parkman.Tests/Domain/ParkingSpotTests.cs
@@ -10,7 +10,7 @@ public class ParkingSpotTests
     [Fact]
     public void Adding_overlapping_reservation_should_throw()
     {
-        var spot = new ParkingSpot("A1", ParkingSpotType.Regular, ParkingSpotAccessibility.None, ParkingSpotAllowedPropulsionType.Any);
+        var spot = new ParkingSpot("1", ParkingSpotType.Regular, ParkingSpotAccessibility.None, ParkingSpotAllowedPropulsionType.Any);
         var first = new Reservation(DateTime.Parse("2024-01-01T10:00:00"), DateTime.Parse("2024-01-01T11:00:00"));
         spot.AddReservation(first);
 
@@ -22,7 +22,7 @@ public class ParkingSpotTests
     [Fact]
     public void Non_overlapping_reservation_should_be_added()
     {
-        var spot = new ParkingSpot("A1", ParkingSpotType.Regular, ParkingSpotAccessibility.None, ParkingSpotAllowedPropulsionType.Any);
+        var spot = new ParkingSpot("1", ParkingSpotType.Regular, ParkingSpotAccessibility.None, ParkingSpotAllowedPropulsionType.Any);
         var first = new Reservation(DateTime.Parse("2024-01-01T10:00:00"), DateTime.Parse("2024-01-01T11:00:00"));
         spot.AddReservation(first);
 
@@ -30,5 +30,15 @@ public class ParkingSpotTests
         spot.AddReservation(second);
 
         Assert.Equal(2, spot.Reservations.Count);
+    }
+
+    [Fact]
+    public void Identifier_should_include_parking_lot_name_and_label()
+    {
+        var lot = new ParkingLot("A", "Some Address");
+        var spot = new ParkingSpot("1", ParkingSpotType.Regular, ParkingSpotAccessibility.None, ParkingSpotAllowedPropulsionType.Any);
+        lot.AddSpot(spot);
+
+        Assert.Equal("A1", spot.Identifier);
     }
 }

--- a/Parkman/Domain/Entities/ParkingLot.cs
+++ b/Parkman/Domain/Entities/ParkingLot.cs
@@ -31,7 +31,7 @@ public class ParkingLot
         Address = address;
     }
 
-    internal void AddSpot(ParkingSpot spot)
+    public void AddSpot(ParkingSpot spot)
     {
         if (spot == null) throw new ArgumentNullException(nameof(spot));
         _spots.Add(spot);

--- a/Parkman/Domain/Entities/ParkingSpot.cs
+++ b/Parkman/Domain/Entities/ParkingSpot.cs
@@ -9,6 +9,8 @@ public class ParkingSpot
 {
     public int Id { get; private set; }
 
+    public string Label { get; private set; } = string.Empty;
+
     public string Identifier { get; private set; } = string.Empty;
 
     public ParkingSpotType Type { get; private set; }
@@ -24,24 +26,25 @@ public class ParkingSpot
     private ParkingSpot() { }
 
     public ParkingSpot(
-        string identifier,
+        string label,
         ParkingSpotType type,
         ParkingSpotAccessibility accessibility,
         ParkingSpotAllowedPropulsionType allowedPropulsion)
     {
-        Update(identifier, type, accessibility, allowedPropulsion);
+        Update(label, type, accessibility, allowedPropulsion);
     }
 
     public void Update(
-        string identifier,
+        string label,
         ParkingSpotType type,
         ParkingSpotAccessibility accessibility,
         ParkingSpotAllowedPropulsionType allowedPropulsion)
     {
-        if (string.IsNullOrWhiteSpace(identifier))
-            throw new ArgumentException("Identifier is required", nameof(identifier));
+        if (string.IsNullOrWhiteSpace(label))
+            throw new ArgumentException("Label is required", nameof(label));
 
-        Identifier = identifier;
+        Label = label;
+        RebuildIdentifier();
         Type = type;
         Accessibility = accessibility;
         AllowedPropulsion = allowedPropulsion;
@@ -51,9 +54,10 @@ public class ParkingSpot
     {
         ParkingLot = lot;
         ParkingLotId = lot.Id;
+        RebuildIdentifier();
     }
 
-    internal void AddReservation(Reservation reservation)
+    public void AddReservation(Reservation reservation)
     {
         if (reservation == null) throw new ArgumentNullException(nameof(reservation));
         if (HasReservationConflict(reservation.StartTime, reservation.EndTime))
@@ -71,5 +75,10 @@ public class ParkingSpot
             throw new ArgumentException("End time must be after start time", nameof(endTime));
 
         return _reservations.Any(r => r.StartTime < endTime && startTime < r.EndTime);
+    }
+
+    private void RebuildIdentifier()
+    {
+        Identifier = ParkingLot != null ? $"{ParkingLot.Name}{Label}" : Label;
     }
 }

--- a/Parkman/Infrastructure/ApplicationDbContext.cs
+++ b/Parkman/Infrastructure/ApplicationDbContext.cs
@@ -112,6 +112,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
         builder.Entity<ParkingSpot>(spot =>
         {
             spot.HasKey(s => s.Id);
+            spot.Property(s => s.Label).IsRequired();
             spot.Property(s => s.Identifier).IsRequired();
             spot.Property(s => s.Type).IsRequired();
             spot.Property(s => s.Accessibility).IsRequired();


### PR DESCRIPTION
## Summary
- add `Label` to `ParkingSpot` and compute `Identifier` from parking lot name + label
- expose `AddSpot` and `AddReservation` publicly
- map the new field in `ApplicationDbContext`
- adjust unit tests and add identifier test

## Testing
- `dotnet test Parkman.sln --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_687cddd10e948326b132fb9731c4de9c