### PR TITLE
Implement generic repository with filtering and sorting

### DIFF
--- a/Parkman/Infrastructure/Repositories/GenericRepository.cs
+++ b/Parkman/Infrastructure/Repositories/GenericRepository.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Parkman.Infrastructure.Repositories
+{
+    public class GenericRepository<TEntity> : IGenericRepository<TEntity>
+        where TEntity : class
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly DbSet<TEntity> _dbSet;
+
+        public GenericRepository(ApplicationDbContext context)
+        {
+            _context = context;
+            _dbSet = _context.Set<TEntity>();
+        }
+
+        public async Task<TEntity?> GetByIdAsync(object id)
+        {
+            return await _dbSet.FindAsync(id);
+        }
+
+        public async Task<IReadOnlyList<TEntity>> ListAsync(
+            Expression<Func<TEntity, bool>>? filter = null,
+            Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+            string includeProperties = "",
+            int? skip = null,
+            int? take = null)
+        {
+            IQueryable<TEntity> query = _dbSet;
+
+            if (filter != null)
+            {
+                query = query.Where(filter);
+            }
+
+            foreach (var includeProperty in includeProperties.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                query = query.Include(includeProperty.Trim());
+            }
+
+            if (orderBy != null)
+            {
+                query = orderBy(query);
+            }
+
+            if (skip.HasValue)
+            {
+                query = query.Skip(skip.Value);
+            }
+            if (take.HasValue)
+            {
+                query = query.Take(take.Value);
+            }
+
+            return await query.AsNoTracking().ToListAsync();
+        }
+
+        public async Task<TEntity> AddAsync(TEntity entity)
+        {
+            await _dbSet.AddAsync(entity);
+            await _context.SaveChangesAsync();
+            return entity;
+        }
+
+        public async Task UpdateAsync(TEntity entity)
+        {
+            _dbSet.Attach(entity);
+            _context.Entry(entity).State = EntityState.Modified;
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task DeleteAsync(TEntity entity)
+        {
+            if (_context.Entry(entity).State == EntityState.Detached)
+            {
+                _dbSet.Attach(entity);
+            }
+            _dbSet.Remove(entity);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/Parkman/Infrastructure/Repositories/IGenericRepository.cs
+++ b/Parkman/Infrastructure/Repositories/IGenericRepository.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace Parkman.Infrastructure.Repositories
+{
+    public interface IGenericRepository<TEntity> where TEntity : class
+    {
+        Task<TEntity?> GetByIdAsync(object id);
+
+        Task<IReadOnlyList<TEntity>> ListAsync(
+            Expression<Func<TEntity, bool>>? filter = null,
+            Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+            string includeProperties = "",
+            int? skip = null,
+            int? take = null);
+
+        Task<TEntity> AddAsync(TEntity entity);
+        Task UpdateAsync(TEntity entity);
+        Task DeleteAsync(TEntity entity);
+    }
+}

--- a/Parkman/Infrastructure/Repositories/RepositoryServiceCollectionExtensions.cs
+++ b/Parkman/Infrastructure/Repositories/RepositoryServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Parkman.Infrastructure.Repositories
+{
+    public static class RepositoryServiceCollectionExtensions
+    {
+        public static IServiceCollection AddGenericRepositories(this IServiceCollection services)
+        {
+            services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
+            return services;
+        }
+    }
+}

--- a/Parkman/Program.cs
+++ b/Parkman/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Parkman.Infrastructure;
+using Parkman.Infrastructure.Repositories;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -12,6 +13,7 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddGenericRepositories();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- add `IGenericRepository` interface for CRUD operations
- implement `GenericRepository` using EF Core with filter, sort, and include support
- add DI extension to register repositories
- register repositories in `Program.cs`

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce90def4883268f97ab3c52aa7569