### PR TITLE
Add paginated repository support

### DIFF
--- a/Parkman.Tests/Infrastructure/PaginationTests.cs
+++ b/Parkman.Tests/Infrastructure/PaginationTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Parkman.Domain.Entities;
+using Parkman.Infrastructure;
+using Parkman.Infrastructure.Repositories;
+using Xunit;
+
+namespace Parkman.Tests.Infrastructure;
+
+public class PaginationTests
+{
+    [Fact]
+    public async Task ListPagedAsync_returns_total_count_and_items()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            context.ParkingLots.Add(new ParkingLot("Lot1", "Addr1"));
+            context.ParkingLots.Add(new ParkingLot("Lot2", "Addr2"));
+            context.ParkingLots.Add(new ParkingLot("Lot3", "Addr3"));
+            await context.SaveChangesAsync();
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repo = new GenericRepository<ParkingLot>(context);
+            var result = await repo.ListPagedAsync(skip:1, take:1);
+
+            Assert.Equal(3, result.TotalCount);
+            Assert.Single(result.Items);
+        }
+    }
+}

--- a/Parkman.Tests/Parkman.Tests.csproj
+++ b/Parkman.Tests/Parkman.Tests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="coverlet.collector" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Parkman\Parkman.csproj" />

--- a/Parkman/Common/PagedResult.cs
+++ b/Parkman/Common/PagedResult.cs
@@ -1,0 +1,13 @@
+namespace Parkman.Common;
+
+public class PagedResult<T>
+{
+    public IReadOnlyList<T> Items { get; }
+    public int TotalCount { get; }
+
+    public PagedResult(IReadOnlyList<T> items, int totalCount)
+    {
+        Items = items;
+        TotalCount = totalCount;
+    }
+}

--- a/Parkman/Infrastructure/Repositories/IGenericRepository.cs
+++ b/Parkman/Infrastructure/Repositories/IGenericRepository.cs
@@ -18,6 +18,14 @@ namespace Parkman.Infrastructure.Repositories
             int? take = null,
             string? search = null);
 
+        Task<Common.PagedResult<TEntity>> ListPagedAsync(
+            Expression<Func<TEntity, bool>>? filter = null,
+            Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+            string includeProperties = "",
+            int? skip = null,
+            int? take = null,
+            string? search = null);
+
         Task<TEntity> AddAsync(TEntity entity);
         Task UpdateAsync(TEntity entity);
         Task DeleteAsync(TEntity entity);


### PR DESCRIPTION
## Summary
- implement `PagedResult<T>` helper
- extend `IGenericRepository` with `ListPagedAsync`
- add pagination implementation in `GenericRepository`
- add unit test using EF Core InMemory
- add EF Core InMemory to test project dependencies

## Testing
- `dotnet test Parkman.Tests/Parkman.Tests.csproj --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687ced669fd08326bc86c92e3f20da5c