### PR TITLE
Add generic service layer

### DIFF
--- a/Parkman/Infrastructure/Services/Entities/ICompanyProfileService.cs
+++ b/Parkman/Infrastructure/Services/Entities/ICompanyProfileService.cs
@@ -1,0 +1,11 @@
+using Parkman.Domain.Entities;
+using Parkman.Infrastructure.Repositories.Entities;
+
+namespace Parkman.Infrastructure.Services.Entities;
+
+public interface ICompanyProfileService : IGenericService<CompanyProfile> { }
+
+public class CompanyProfileService : GenericService<CompanyProfile>, ICompanyProfileService
+{
+    public CompanyProfileService(ICompanyProfileRepository repository) : base(repository) { }
+}

--- a/Parkman/Infrastructure/Services/Entities/ICompanyReservationService.cs
+++ b/Parkman/Infrastructure/Services/Entities/ICompanyReservationService.cs
@@ -1,0 +1,11 @@
+using Parkman.Domain.Entities;
+using Parkman.Infrastructure.Repositories.Entities;
+
+namespace Parkman.Infrastructure.Services.Entities;
+
+public interface ICompanyReservationService : IGenericService<CompanyReservation> { }
+
+public class CompanyReservationService : GenericService<CompanyReservation>, ICompanyReservationService
+{
+    public CompanyReservationService(ICompanyReservationRepository repository) : base(repository) { }
+}

--- a/Parkman/Infrastructure/Services/Entities/IParkingLotService.cs
+++ b/Parkman/Infrastructure/Services/Entities/IParkingLotService.cs
@@ -1,0 +1,11 @@
+using Parkman.Domain.Entities;
+using Parkman.Infrastructure.Repositories.Entities;
+
+namespace Parkman.Infrastructure.Services.Entities;
+
+public interface IParkingLotService : IGenericService<ParkingLot> { }
+
+public class ParkingLotService : GenericService<ParkingLot>, IParkingLotService
+{
+    public ParkingLotService(IParkingLotRepository repository) : base(repository) { }
+}

--- a/Parkman/Infrastructure/Services/Entities/IParkingSpotService.cs
+++ b/Parkman/Infrastructure/Services/Entities/IParkingSpotService.cs
@@ -1,0 +1,11 @@
+using Parkman.Domain.Entities;
+using Parkman.Infrastructure.Repositories.Entities;
+
+namespace Parkman.Infrastructure.Services.Entities;
+
+public interface IParkingSpotService : IGenericService<ParkingSpot> { }
+
+public class ParkingSpotService : GenericService<ParkingSpot>, IParkingSpotService
+{
+    public ParkingSpotService(IParkingSpotRepository repository) : base(repository) { }
+}

--- a/Parkman/Infrastructure/Services/Entities/IPersonProfileService.cs
+++ b/Parkman/Infrastructure/Services/Entities/IPersonProfileService.cs
@@ -1,0 +1,11 @@
+using Parkman.Domain.Entities;
+using Parkman.Infrastructure.Repositories.Entities;
+
+namespace Parkman.Infrastructure.Services.Entities;
+
+public interface IPersonProfileService : IGenericService<PersonProfile> { }
+
+public class PersonProfileService : GenericService<PersonProfile>, IPersonProfileService
+{
+    public PersonProfileService(IPersonProfileRepository repository) : base(repository) { }
+}

--- a/Parkman/Infrastructure/Services/Entities/IProfileReservationService.cs
+++ b/Parkman/Infrastructure/Services/Entities/IProfileReservationService.cs
@@ -1,0 +1,11 @@
+using Parkman.Domain.Entities;
+using Parkman.Infrastructure.Repositories.Entities;
+
+namespace Parkman.Infrastructure.Services.Entities;
+
+public interface IProfileReservationService : IGenericService<ProfileReservation> { }
+
+public class ProfileReservationService : GenericService<ProfileReservation>, IProfileReservationService
+{
+    public ProfileReservationService(IProfileReservationRepository repository) : base(repository) { }
+}

--- a/Parkman/Infrastructure/Services/Entities/IReservationService.cs
+++ b/Parkman/Infrastructure/Services/Entities/IReservationService.cs
@@ -1,0 +1,11 @@
+using Parkman.Domain.Entities;
+using Parkman.Infrastructure.Repositories.Entities;
+
+namespace Parkman.Infrastructure.Services.Entities;
+
+public interface IReservationService : IGenericService<Reservation> { }
+
+public class ReservationService : GenericService<Reservation>, IReservationService
+{
+    public ReservationService(IReservationRepository repository) : base(repository) { }
+}

--- a/Parkman/Infrastructure/Services/Entities/IVehicleService.cs
+++ b/Parkman/Infrastructure/Services/Entities/IVehicleService.cs
@@ -1,0 +1,11 @@
+using Parkman.Domain.Entities;
+using Parkman.Infrastructure.Repositories.Entities;
+
+namespace Parkman.Infrastructure.Services.Entities;
+
+public interface IVehicleService : IGenericService<Vehicle> { }
+
+public class VehicleService : GenericService<Vehicle>, IVehicleService
+{
+    public VehicleService(IVehicleRepository repository) : base(repository) { }
+}

--- a/Parkman/Infrastructure/Services/GenericService.cs
+++ b/Parkman/Infrastructure/Services/GenericService.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Parkman.Infrastructure.Repositories;
+
+namespace Parkman.Infrastructure.Services;
+
+public class GenericService<TEntity> : IGenericService<TEntity>
+    where TEntity : class
+{
+    private readonly IGenericRepository<TEntity> _repository;
+
+    public GenericService(IGenericRepository<TEntity> repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<TEntity?> GetByIdAsync(object id)
+    {
+        return _repository.GetByIdAsync(id);
+    }
+
+    public Task<IReadOnlyList<TEntity>> ListAsync(
+        Expression<Func<TEntity, bool>>? filter = null,
+        Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+        string includeProperties = "",
+        int? skip = null,
+        int? take = null,
+        string? search = null)
+    {
+        return _repository.ListAsync(filter, orderBy, includeProperties, skip, take, search);
+    }
+
+    public Task<Common.PagedResult<TEntity>> ListPagedAsync(
+        Expression<Func<TEntity, bool>>? filter = null,
+        Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+        string includeProperties = "",
+        int? skip = null,
+        int? take = null,
+        string? search = null)
+    {
+        return _repository.ListPagedAsync(filter, orderBy, includeProperties, skip, take, search);
+    }
+
+    public Task<TEntity> AddAsync(TEntity entity)
+    {
+        return _repository.AddAsync(entity);
+    }
+
+    public Task UpdateAsync(TEntity entity)
+    {
+        return _repository.UpdateAsync(entity);
+    }
+
+    public Task DeleteAsync(TEntity entity)
+    {
+        return _repository.DeleteAsync(entity);
+    }
+}

--- a/Parkman/Infrastructure/Services/IGenericService.cs
+++ b/Parkman/Infrastructure/Services/IGenericService.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace Parkman.Infrastructure.Services;
+
+public interface IGenericService<TEntity> where TEntity : class
+{
+    Task<TEntity?> GetByIdAsync(object id);
+
+    Task<IReadOnlyList<TEntity>> ListAsync(
+        Expression<Func<TEntity, bool>>? filter = null,
+        Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+        string includeProperties = "",
+        int? skip = null,
+        int? take = null,
+        string? search = null);
+
+    Task<Common.PagedResult<TEntity>> ListPagedAsync(
+        Expression<Func<TEntity, bool>>? filter = null,
+        Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
+        string includeProperties = "",
+        int? skip = null,
+        int? take = null,
+        string? search = null);
+
+    Task<TEntity> AddAsync(TEntity entity);
+    Task UpdateAsync(TEntity entity);
+    Task DeleteAsync(TEntity entity);
+}

--- a/Parkman/Infrastructure/Services/ServiceServiceCollectionExtensions.cs
+++ b/Parkman/Infrastructure/Services/ServiceServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Parkman.Infrastructure.Services;
+
+public static class ServiceServiceCollectionExtensions
+{
+    public static IServiceCollection AddServices(this IServiceCollection services)
+    {
+        services.AddScoped(typeof(IGenericService<>), typeof(GenericService<>));
+        services.AddScoped<Entities.IParkingLotService, Entities.ParkingLotService>();
+        services.AddScoped<Entities.IParkingSpotService, Entities.ParkingSpotService>();
+        services.AddScoped<Entities.IPersonProfileService, Entities.PersonProfileService>();
+        services.AddScoped<Entities.ICompanyProfileService, Entities.CompanyProfileService>();
+        services.AddScoped<Entities.IVehicleService, Entities.VehicleService>();
+        services.AddScoped<Entities.IReservationService, Entities.ReservationService>();
+        services.AddScoped<Entities.IProfileReservationService, Entities.ProfileReservationService>();
+        services.AddScoped<Entities.ICompanyReservationService, Entities.CompanyReservationService>();
+        return services;
+    }
+}

--- a/Parkman/Program.cs
+++ b/Parkman/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Parkman.Infrastructure;
 using Parkman.Infrastructure.Repositories;
+using Parkman.Infrastructure.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,6 +15,7 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddRepositories();
+builder.Services.AddServices();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- create `IGenericService` and `GenericService` for CRUD operations
- add per-entity service wrappers
- register services via `AddServices`
- wire up service registration in `Program.cs`

## Testing
- `dotnet test Parkman.Tests/Parkman.Tests.csproj --logger "console;verbosity=detailed"`

------
https://chatgpt.com/codex/tasks/task_e_687cf9d6bc9c83268b6c915342cfe3a5