### PR TITLE
Implement basic auth endpoints

### DIFF
--- a/Parkman/Controllers/AuthController.cs
+++ b/Parkman/Controllers/AuthController.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Parkman.Domain.Entities;
+using Parkman.Models;
+
+namespace Parkman.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly SignInManager<ApplicationUser> _signInManager;
+
+    public AuthController(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager)
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+    }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register(RegisterRequest request)
+    {
+        if(!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var user = new ApplicationUser { UserName = request.Email, Email = request.Email };
+        var result = await _userManager.CreateAsync(user, request.Password);
+        if(!result.Succeeded)
+        {
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(error.Code, error.Description);
+            }
+            return ValidationProblem(ModelState);
+        }
+        await _signInManager.SignInAsync(user, isPersistent: false);
+        return Ok();
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login(LoginRequest request)
+    {
+        if(!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var result = await _signInManager.PasswordSignInAsync(request.Email, request.Password, false, false);
+        if(result.Succeeded)
+        {
+            return Ok();
+        }
+        return Unauthorized();
+    }
+}

--- a/Parkman/Models/LoginRequest.cs
+++ b/Parkman/Models/LoginRequest.cs
@@ -1,0 +1,7 @@
+namespace Parkman.Models;
+
+public class LoginRequest
+{
+    public string Email { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/Parkman/Models/RegisterRequest.cs
+++ b/Parkman/Models/RegisterRequest.cs
@@ -1,0 +1,7 @@
+namespace Parkman.Models;
+
+public class RegisterRequest
+{
+    public string Email { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+}

--- a/Parkman/Parkman.http
+++ b/Parkman/Parkman.http
@@ -4,3 +4,23 @@ GET {{Parkman_HostAddress}}/weatherforecast/
 Accept: application/json
 
 ###
+
+POST {{Parkman_HostAddress}}/api/auth/register
+Content-Type: application/json
+
+{
+  "email": "user@example.com",
+  "password": "Password123!"
+}
+
+###
+
+POST {{Parkman_HostAddress}}/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "user@example.com",
+  "password": "Password123!"
+}
+
+###

--- a/Parkman/Program.cs
+++ b/Parkman/Program.cs
@@ -1,4 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity;
+using Parkman.Domain.Entities;
 using Parkman.Infrastructure;
 using Parkman.Infrastructure.Repositories;
 using Parkman.Infrastructure.Services;
@@ -9,6 +11,10 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.AddIdentity<ApplicationUser, IdentityRole>()
+    .AddEntityFrameworkStores<ApplicationDbContext>()
+    .AddDefaultTokenProviders();
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -27,6 +33,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseAuthentication();
 
 app.UseAuthorization();
 


### PR DESCRIPTION
## Summary
- add Identity services and authentication setup
- implement new `AuthController` for registering and logging in users
- create request DTOs for login and registration
- document auth endpoints in `Parkman.http`

## Testing
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687d05e4b450832685e0a95f15b77fcb