### PR TITLE
Add company registration endpoint

### DIFF
--- a/Parkman/Controllers/RegistrationController.cs
+++ b/Parkman/Controllers/RegistrationController.cs
@@ -8,11 +8,15 @@ namespace Parkman.Controllers;
 [Route("api/[controller]")]
 public class RegistrationController : ControllerBase
 {
-    private readonly IUserVehicleRegistrationService _service;
+    private readonly IUserVehicleRegistrationService _vehicleRegistrationService;
+    private readonly IUserCompanyRegistrationService _companyRegistrationService;
 
-    public RegistrationController(IUserVehicleRegistrationService service)
+    public RegistrationController(
+        IUserVehicleRegistrationService vehicleRegistrationService,
+        IUserCompanyRegistrationService companyRegistrationService)
     {
-        _service = service;
+        _vehicleRegistrationService = vehicleRegistrationService;
+        _companyRegistrationService = companyRegistrationService;
     }
 
     [HttpPost]
@@ -21,7 +25,7 @@ public class RegistrationController : ControllerBase
         if (!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
-        var result = await _service.RegisterAsync(
+        var result = await _vehicleRegistrationService.RegisterAsync(
             request.Email,
             request.Password,
             request.FirstName,
@@ -34,6 +38,35 @@ public class RegistrationController : ControllerBase
             request.Type,
             request.PropulsionType,
             request.Shareable);
+
+        if (!result.Succeeded)
+        {
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(error.Code, error.Description);
+            }
+            return ValidationProblem(ModelState);
+        }
+
+        return Ok();
+    }
+
+    [HttpPost("company")]
+    public async Task<IActionResult> RegisterCompany(RegisterCompanyRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var result = await _companyRegistrationService.RegisterAsync(
+            request.Email,
+            request.Password,
+            request.CompanyName,
+            request.Ico,
+            request.Dic,
+            request.ContactPersonName,
+            request.ContactEmail,
+            request.PhoneNumber,
+            request.BillingAddress);
 
         if (!result.Succeeded)
         {

--- a/Parkman/Infrastructure/Services/ServiceServiceCollectionExtensions.cs
+++ b/Parkman/Infrastructure/Services/ServiceServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class ServiceServiceCollectionExtensions
         services.AddScoped<Entities.IProfileReservationService, Entities.ProfileReservationService>();
         services.AddScoped<Entities.ICompanyReservationService, Entities.CompanyReservationService>();
         services.AddScoped<IUserVehicleRegistrationService, UserVehicleRegistrationService>();
+        services.AddScoped<IUserCompanyRegistrationService, UserCompanyRegistrationService>();
         return services;
     }
 }

--- a/Parkman/Infrastructure/Services/UserCompanyRegistrationService.cs
+++ b/Parkman/Infrastructure/Services/UserCompanyRegistrationService.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Identity;
+using Parkman.Domain.Entities;
+using Parkman.Infrastructure.Repositories.Entities;
+
+namespace Parkman.Infrastructure.Services;
+
+public interface IUserCompanyRegistrationService
+{
+    Task<IdentityResult> RegisterAsync(
+        string email,
+        string password,
+        string companyName,
+        string ico,
+        string dic,
+        string contactPersonName,
+        string contactEmail,
+        string phoneNumber,
+        string billingAddress);
+}
+
+public class UserCompanyRegistrationService : IUserCompanyRegistrationService
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly ICompanyProfileRepository _companyRepo;
+
+    public UserCompanyRegistrationService(
+        UserManager<ApplicationUser> userManager,
+        ICompanyProfileRepository companyRepo)
+    {
+        _userManager = userManager;
+        _companyRepo = companyRepo;
+    }
+
+    public async Task<IdentityResult> RegisterAsync(
+        string email,
+        string password,
+        string companyName,
+        string ico,
+        string dic,
+        string contactPersonName,
+        string contactEmail,
+        string phoneNumber,
+        string billingAddress)
+    {
+        var user = new ApplicationUser { UserName = email, Email = email };
+        var createResult = await _userManager.CreateAsync(user, password);
+        if (!createResult.Succeeded)
+        {
+            return createResult;
+        }
+
+        var profile = new CompanyProfile(companyName, ico, dic, contactPersonName, contactEmail, phoneNumber, billingAddress);
+        user.SetCompanyProfile(profile);
+        await _companyRepo.AddAsync(profile);
+
+        return createResult;
+    }
+}

--- a/Parkman/Models/RegisterCompanyRequest.cs
+++ b/Parkman/Models/RegisterCompanyRequest.cs
@@ -1,0 +1,15 @@
+namespace Parkman.Models;
+
+public class RegisterCompanyRequest
+{
+    public string Email { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+
+    public string CompanyName { get; set; } = string.Empty;
+    public string Ico { get; set; } = string.Empty;
+    public string Dic { get; set; } = string.Empty;
+    public string ContactPersonName { get; set; } = string.Empty;
+    public string ContactEmail { get; set; } = string.Empty;
+    public string PhoneNumber { get; set; } = string.Empty;
+    public string BillingAddress { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- allow registering a company by adding `UserCompanyRegistrationService`
- add `RegisterCompanyRequest` model
- extend `RegistrationController` with `/company` endpoint
- wire service into DI

## Testing
- `dotnet build Parkman.sln -c Release`
- `dotnet test Parkman.sln`


------
https://chatgpt.com/codex/tasks/task_e_687d114e94088326998730d6f27fe83b