### PR TITLE
Add Blazor WebAssembly registration frontend

### DIFF
--- a/Parkman.Frontend/App.razor
+++ b/Parkman.Frontend/App.razor
@@ -1,0 +1,10 @@
+<Router AppAssembly="@typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="@typeof(MainLayout)">
+            <p>Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/Parkman.Frontend/Pages/Index.razor
+++ b/Parkman.Frontend/Pages/Index.razor
@@ -1,0 +1,6 @@
+@page "/"
+
+<h1>Hello, world!</h1>
+
+Welcome to your new app.
+

--- a/Parkman.Frontend/Pages/Register.razor
+++ b/Parkman.Frontend/Pages/Register.razor
@@ -1,0 +1,87 @@
+@page "/register"
+@using System.Net.Http.Json
+
+<h3>Register</h3>
+
+<EditForm Model="_model" OnValidSubmit="RegisterUser">
+    <DataAnnotationsValidator />
+    <ValidationSummary />
+
+    <div>
+        <label>Email:</label>
+        <InputText @bind-Value="_model.Email" />
+    </div>
+    <div>
+        <label>Password:</label>
+        <InputText @bind-Value="_model.Password" type="password" />
+    </div>
+    <div>
+        <label>First name:</label>
+        <InputText @bind-Value="_model.FirstName" />
+    </div>
+    <div>
+        <label>Last name:</label>
+        <InputText @bind-Value="_model.LastName" />
+    </div>
+    <div>
+        <label>Date of birth:</label>
+        <InputDate @bind-Value="_model.DateOfBirth" />
+    </div>
+    <div>
+        <label>Phone number:</label>
+        <InputText @bind-Value="_model.PhoneNumber" />
+    </div>
+    <div>
+        <label>Address:</label>
+        <InputText @bind-Value="_model.Address" />
+    </div>
+    <div>
+        <label>License plate:</label>
+        <InputText @bind-Value="_model.LicensePlate" />
+    </div>
+    <div>
+        <label>Brand:</label>
+        <InputText @bind-Value="_model.Brand" />
+    </div>
+    <div>
+        <label>Type:</label>
+        <InputText @bind-Value="_model.Type" />
+    </div>
+    <div>
+        <label>Propulsion type:</label>
+        <InputText @bind-Value="_model.PropulsionType" />
+    </div>
+    <div>
+        <label>Shareable:</label>
+        <InputCheckbox @bind-Value="_model.Shareable" />
+    </div>
+
+    <button type="submit">Register</button>
+</EditForm>
+
+@code {
+    private RegisterWithVehicleRequest _model = new();
+
+    [Inject] private HttpClient Http { get; set; } = default!;
+
+    private async Task RegisterUser()
+    {
+        await Http.PostAsJsonAsync("api/Registration", _model);
+    }
+
+    public class RegisterWithVehicleRequest
+    {
+        public string Email { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+        public DateOnly? DateOfBirth { get; set; }
+        public string PhoneNumber { get; set; } = string.Empty;
+        public string Address { get; set; } = string.Empty;
+        public string LicensePlate { get; set; } = string.Empty;
+        public string Brand { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+        public string PropulsionType { get; set; } = string.Empty;
+        public bool Shareable { get; set; }
+    }
+}

--- a/Parkman.Frontend/Parkman.Frontend.csproj
+++ b/Parkman.Frontend/Parkman.Frontend.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>Parkman.Frontend</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/Parkman.Frontend/Program.cs
+++ b/Parkman.Frontend/Program.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+namespace Parkman.Frontend;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        var builder = WebAssemblyHostBuilder.CreateDefault(args);
+        builder.RootComponents.Add<App>("#app");
+        builder.RootComponents.Add<HeadOutlet>("head::after");
+
+        builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+        await builder.Build().RunAsync();
+    }
+}

--- a/Parkman.Frontend/Shared/MainLayout.razor
+++ b/Parkman.Frontend/Shared/MainLayout.razor
@@ -1,0 +1,8 @@
+@inherits LayoutComponentBase
+
+<div class="main">
+    <NavMenu />
+    <div class="content">
+        @Body
+    </div>
+</div>

--- a/Parkman.Frontend/Shared/NavMenu.razor
+++ b/Parkman.Frontend/Shared/NavMenu.razor
@@ -1,0 +1,6 @@
+<nav>
+    <ul>
+        <li><a href="/">Home</a></li>
+        <li><a href="/register">Register</a></li>
+    </ul>
+</nav>

--- a/Parkman.Frontend/wwwroot/index.html
+++ b/Parkman.Frontend/wwwroot/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Parkman Frontend</title>
+    <base href="/" />
+</head>
+<body>
+    <div id="app">Loading...</div>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>

--- a/Parkman.sln
+++ b/Parkman.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Parkman", "Parkman\Parkman.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Parkman.Tests", "Parkman.Tests\Parkman.Tests.csproj", "{3DABF74D-8E26-4AD7-84E4-AB872D0EFD6D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Parkman.Frontend", "Parkman.Frontend\Parkman.Frontend.csproj", "{6BB9D6AC-569F-5C73-412A-D143FBE529FC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ GlobalSection(ProjectConfigurationPlatforms) = postSolution
 {3DABF74D-8E26-4AD7-84E4-AB872D0EFD6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {3DABF74D-8E26-4AD7-84E4-AB872D0EFD6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 {3DABF74D-8E26-4AD7-84E4-AB872D0EFD6D}.Release|Any CPU.Build.0 = Release|Any CPU
+{6BB9D6AC-569F-5C73-412A-D143FBE529FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{6BB9D6AC-569F-5C73-412A-D143FBE529FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{6BB9D6AC-569F-5C73-412A-D143FBE529FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{6BB9D6AC-569F-5C73-412A-D143FBE529FC}.Release|Any CPU.Build.0 = Release|Any CPU
 EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add a new `Parkman.Frontend` Blazor WebAssembly project
- implement a simple registration form in `Register.razor`
- include minimal layout and pages
- update solution file to reference the new project

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d23e784cc8326b649c64892dfb115