### PR TITLE
Fix frontend build errors

### DIFF
--- a/Parkman.Frontend/Program.cs
+++ b/Parkman.Frontend/Program.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Net.Http;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 

--- a/Parkman.Frontend/_Imports.razor
+++ b/Parkman.Frontend/_Imports.razor
@@ -1,0 +1,10 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using Parkman.Frontend
+@using Parkman.Frontend.Shared


### PR DESCRIPTION
## Summary
- add missing using statements in Program
- provide standard `_Imports.razor` for Blazor components

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d28303bc88326874cd3fe1d553d82