### PR TITLE
Improve registration page UX

### DIFF
--- a/Parkman.Frontend/Pages/Register.razor
+++ b/Parkman.Frontend/Pages/Register.razor
@@ -1,5 +1,6 @@
 @page "/register"
 @using System.Net.Http.Json
+@using System.ComponentModel.DataAnnotations
 
 <h3 class="text-2xl font-bold mb-4 text-center text-headline">Register</h3>
 
@@ -10,78 +11,142 @@
     <div class="mb-4">
         <label class="block text-sm font-medium text-headline">Email</label>
         <InputText @bind-Value="_model.Email" class="mt-1 block w-full rounded-md border-stroke shadow-sm focus:border-highlight focus:ring-highlight" />
+        <ValidationMessage For="@(() => _model.Email)" class="text-red-500 text-sm mt-1" />
     </div>
     <div class="mb-4">
         <label class="block text-sm font-medium text-headline">Password</label>
-        <InputText @bind-Value="_model.Password" type="password" class="mt-1 block w-full rounded-md border-stroke shadow-sm focus:border-highlight focus:ring-highlight" />
+        <div class="flex items-center">
+            <InputText @bind-Value="_model.Password" type="@(showPassword ? "text" : "password")" class="mt-1 block w-full rounded-md border-stroke shadow-sm focus:border-highlight focus:ring-highlight" />
+            <button type="button" class="ml-2 text-sm text-paragraph" @onclick="() => showPassword = !showPassword">@(showPassword ? "Hide" : "Show")</button>
+        </div>
+        <ValidationMessage For="@(() => _model.Password)" class="text-red-500 text-sm mt-1" />
+    </div>
+    <div class="mb-4">
+        <label class="block text-sm font-medium text-headline">Confirm password</label>
+        <InputText @bind-Value="_model.ConfirmPassword" type="@(showPassword ? "text" : "password")" class="mt-1 block w-full rounded-md border-stroke shadow-sm focus:border-highlight focus:ring-highlight" />
+        <ValidationMessage For="@(() => _model.ConfirmPassword)" class="text-red-500 text-sm mt-1" />
     </div>
     <div class="mb-4">
         <label class="block text-sm font-medium text-headline">First name</label>
         <InputText @bind-Value="_model.FirstName" class="mt-1 block w-full rounded-md border-stroke shadow-sm focus:border-highlight focus:ring-highlight" />
+        <ValidationMessage For="@(() => _model.FirstName)" class="text-red-500 text-sm mt-1" />
     </div>
     <div class="mb-4">
         <label class="block text-sm font-medium text-headline">Last name</label>
         <InputText @bind-Value="_model.LastName" class="mt-1 block w-full rounded-md border-stroke shadow-sm focus:border-highlight focus:ring-highlight" />
+        <ValidationMessage For="@(() => _model.LastName)" class="text-red-500 text-sm mt-1" />
     </div>
     <div class="mb-4">
         <label class="block text-sm font-medium text-headline">Date of birth</label>
         <InputDate @bind-Value="_model.DateOfBirth" class="mt-1 block w-full rounded-md border-stroke shadow-sm focus:border-highlight focus:ring-highlight" />
+        <ValidationMessage For="@(() => _model.DateOfBirth)" class="text-red-500 text-sm mt-1" />
     </div>
     <div class="mb-4">
         <label class="block text-sm font-medium text-headline">Phone number</label>
         <InputText @bind-Value="_model.PhoneNumber" class="mt-1 block w-full rounded-md border-stroke shadow-sm focus:border-highlight focus:ring-highlight" />
+        <ValidationMessage For="@(() => _model.PhoneNumber)" class="text-red-500 text-sm mt-1" />
     </div>
     <div class="mb-4">
         <label class="block text-sm font-medium text-headline">Address</label>
         <InputText @bind-Value="_model.Address" class="mt-1 block w-full rounded-md border-stroke shadow-sm focus:border-highlight focus:ring-highlight" />
+        <ValidationMessage For="@(() => _model.Address)" class="text-red-500 text-sm mt-1" />
     </div>
     <div class="mb-4">
         <label class="block text-sm font-medium text-headline">License plate</label>
         <InputText @bind-Value="_model.LicensePlate" class="mt-1 block w-full rounded-md border-stroke shadow-sm focus:border-highlight focus:ring-highlight" />
+        <ValidationMessage For="@(() => _model.LicensePlate)" class="text-red-500 text-sm mt-1" />
     </div>
     <div class="mb-4">
         <label class="block text-sm font-medium text-headline">Brand</label>
         <InputText @bind-Value="_model.Brand" class="mt-1 block w-full rounded-md border-stroke shadow-sm focus:border-highlight focus:ring-highlight" />
+        <ValidationMessage For="@(() => _model.Brand)" class="text-red-500 text-sm mt-1" />
     </div>
     <div class="mb-4">
         <label class="block text-sm font-medium text-headline">Type</label>
         <InputText @bind-Value="_model.Type" class="mt-1 block w-full rounded-md border-stroke shadow-sm focus:border-highlight focus:ring-highlight" />
+        <ValidationMessage For="@(() => _model.Type)" class="text-red-500 text-sm mt-1" />
     </div>
     <div class="mb-4">
         <label class="block text-sm font-medium text-headline">Propulsion type</label>
         <InputText @bind-Value="_model.PropulsionType" class="mt-1 block w-full rounded-md border-stroke shadow-sm focus:border-highlight focus:ring-highlight" />
+        <ValidationMessage For="@(() => _model.PropulsionType)" class="text-red-500 text-sm mt-1" />
     </div>
     <div class="flex items-center mb-6">
         <InputCheckbox @bind-Value="_model.Shareable" class="h-4 w-4 text-highlight border-stroke rounded" />
         <label class="ml-2 block text-sm text-headline">Shareable</label>
     </div>
 
-    <button type="submit" class="w-full bg-highlight text-button-text py-2 px-4 rounded hover:bg-tertiary">Register</button>
+    <button type="submit" class="w-full bg-highlight text-button-text py-2 px-4 rounded hover:bg-tertiary disabled:opacity-50" disabled="@isSubmitting">
+        @(isSubmitting ? "Registering..." : "Register")
+    </button>
+    @if (successMessage != null)
+    {
+        <p class="text-green-600 text-center mt-4">@successMessage</p>
+    }
 </EditForm>
 
 @code {
     private RegisterWithVehicleRequest _model = new();
 
+    private bool showPassword;
+    private bool isSubmitting;
+    private string? successMessage;
+
     [Inject] private HttpClient Http { get; set; } = default!;
 
     private async Task RegisterUser()
     {
-        await Http.PostAsJsonAsync("api/Registration", _model);
+        isSubmitting = true;
+        successMessage = null;
+        var response = await Http.PostAsJsonAsync("api/Registration", _model);
+
+        if (response.IsSuccessStatusCode)
+        {
+            successMessage = "Registration successful!";
+            _model = new RegisterWithVehicleRequest();
+        }
+
+        isSubmitting = false;
     }
 
     public class RegisterWithVehicleRequest
     {
+        [Required, EmailAddress]
         public string Email { get; set; } = string.Empty;
+
+        [Required]
         public string Password { get; set; } = string.Empty;
+
+        [Required, Compare(nameof(Password))]
+        public string ConfirmPassword { get; set; } = string.Empty;
+
+        [Required]
         public string FirstName { get; set; } = string.Empty;
+
+        [Required]
         public string LastName { get; set; } = string.Empty;
+
+        [Required]
         public DateOnly? DateOfBirth { get; set; }
+
+        [Required, Phone]
         public string PhoneNumber { get; set; } = string.Empty;
+
+        [Required]
         public string Address { get; set; } = string.Empty;
+
+        [Required]
         public string LicensePlate { get; set; } = string.Empty;
+
+        [Required]
         public string Brand { get; set; } = string.Empty;
+
+        [Required]
         public string Type { get; set; } = string.Empty;
+
+        [Required]
         public string PropulsionType { get; set; } = string.Empty;
+
         public bool Shareable { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- enhance Register page visuals
- add validation messages and data annotations
- add confirm password, show/hide toggle and success message

## Testing
- `dotnet build Parkman.sln --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d5dac23e48326bd8bba91d9ad0226