### PR TITLE
Add Blazorise integration

### DIFF
--- a/Parkman.Frontend/Parkman.Frontend.csproj
+++ b/Parkman.Frontend/Parkman.Frontend.csproj
@@ -4,6 +4,9 @@
     <RootNamespace>Parkman.Frontend</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Blazorise" Version="1.2.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="1.2.0" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>

--- a/Parkman.Frontend/Program.cs
+++ b/Parkman.Frontend/Program.cs
@@ -4,6 +4,9 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
+using Blazorise;
+using Blazorise.Bootstrap5;
+using Blazorise.Icons.FontAwesome;
 
 namespace Parkman.Frontend;
 
@@ -14,6 +17,11 @@ public class Program
         var builder = WebAssemblyHostBuilder.CreateDefault(args);
         builder.RootComponents.Add<App>("#app");
         builder.RootComponents.Add<HeadOutlet>("head::after");
+
+        builder.Services
+            .AddBlazorise(options => { options.Immediate = true; })
+            .AddBootstrap5Providers()
+            .AddFontAwesomeIcons();
 
         builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 

--- a/Parkman.Frontend/_Imports.razor
+++ b/Parkman.Frontend/_Imports.razor
@@ -1,6 +1,4 @@
 @using System.Net.Http
-@using Microsoft.AspNetCore.Authorization
-@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web

--- a/Parkman.Frontend/wwwroot/index.html
+++ b/Parkman.Frontend/wwwroot/index.html
@@ -6,6 +6,9 @@
     <title>Parkman Frontend</title>
     <base href="/" />
     <script src="https://cdn.tailwindcss.com"></script>
+    <link href="_content/Blazorise/blazorise.css" rel="stylesheet" />
+    <link href="_content/Blazorise.Bootstrap5/blazorise.bootstrap5.css" rel="stylesheet" />
+    <link href="_content/Blazorise.Icons.FontAwesome/blazorise.icons.fontawesome.css" rel="stylesheet" />
     <script>
         tailwind.config = {
             theme: {
@@ -29,6 +32,8 @@
 </head>
 <body class="bg-background text-paragraph">
     <div id="app">Loading...</div>
+    <script src="_content/Blazorise/blazorise.js"></script>
+    <script src="_content/Blazorise.Bootstrap5/blazorise.bootstrap5.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Blazorise packages
- configure Blazorise services
- include Blazorise CSS/JS assets
- fix `_Imports.razor`

## Testing
- `dotnet build Parkman.Frontend/Parkman.Frontend.csproj`
- `dotnet test Parkman.sln` *(fails: NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_687df29311f8832680f00ec34713d6d2