### PR TITLE
Add landing page header and footer

### DIFF
--- a/Parkman.Frontend/Pages/Index.razor
+++ b/Parkman.Frontend/Pages/Index.razor
@@ -1,7 +1,17 @@
 @page "/"
 
+<header class="bg-highlight text-button-text">
+    <div class="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
+        <h1 class="text-2xl font-bold">Parkman</h1>
+        <nav class="space-x-4">
+            <a href="/" class="hover:text-tertiary">Domů</a>
+            <a href="/register" class="hover:text-tertiary">Registrace</a>
+        </nav>
+    </div>
+</header>
+
 <section class="text-center py-20 bg-main">
-    <h1 class="text-5xl font-bold text-headline mb-4">Parkman</h1>
+    <h2 class="text-5xl font-bold text-headline mb-4">Parkman</h2>
     <p class="text-xl text-paragraph mb-8">Jednoduchý systém pro rezervaci parkovacích míst.</p>
     <a href="/register" class="px-6 py-3 bg-highlight text-button-text rounded-md shadow-md hover:bg-tertiary transition-colors">Začít rezervovat</a>
 </section>
@@ -31,3 +41,7 @@
     <h2 class="text-3xl font-semibold text-headline mb-4">Přidejte se k nám ještě dnes</h2>
     <a href="/register" class="px-6 py-3 bg-highlight text-button-text rounded-md shadow-md hover:bg-tertiary transition-colors">Vytvořit účet</a>
 </section>
+
+<footer class="bg-highlight text-button-text py-4 text-center">
+    &copy; 2023 Parkman. Všechna práva vyhrazena.
+</footer>

--- a/Parkman.Frontend/Pages/Register.razor
+++ b/Parkman.Frontend/Pages/Register.razor
@@ -2,6 +2,8 @@
 @using System.Net.Http.Json
 @using System.ComponentModel.DataAnnotations
 
+<div class="container mx-auto p-4">
+
 <h3 class="text-2xl font-bold mb-4 text-center text-headline">Register</h3>
 
 <div class="flex justify-center space-x-4 mb-4">
@@ -326,12 +328,15 @@ else
         @(isSubmitting ? "Registering..." : "Register")
     </button>
 
+
     @if (successMessage != null)
     {
         <p class="text-green-600 text-center mt-4">@successMessage</p>
     }
 </EditForm>
 }
+
+</div>
 
 @code {
     private RegisterWithVehicleRequest _model = new();


### PR DESCRIPTION
## Summary
- add navigation header and footer to `Index.razor`
- wrap registration page content in a Tailwind container for better layout

## Testing
- `dotnet build Parkman.sln -v minimal` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687e21f059d48326b3db7df5a082e226