### PR TITLE
Fix duplicated menu on landing page

### DIFF
--- a/Parkman.Frontend/Pages/Index.razor
+++ b/Parkman.Frontend/Pages/Index.razor
@@ -1,14 +1,5 @@
 @page "/"
 
-<header class="bg-highlight text-button-text">
-    <div class="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
-        <h1 class="text-2xl font-bold">Parkman</h1>
-        <nav class="space-x-4">
-            <a href="/" class="hover:text-tertiary">Domů</a>
-            <a href="/register" class="hover:text-tertiary">Registrace</a>
-        </nav>
-    </div>
-</header>
 
 <section class="text-center py-20 bg-main">
     <h2 class="text-5xl font-bold text-headline mb-4">Parkman</h2>

--- a/Parkman.Frontend/Shared/NavMenu.razor
+++ b/Parkman.Frontend/Shared/NavMenu.razor
@@ -1,6 +1,9 @@
-<nav class="bg-highlight p-4 text-button-text">
-    <ul class="flex space-x-4">
-        <li><a href="/" class="hover:text-tertiary">Home</a></li>
-        <li><a href="/register" class="hover:text-tertiary">Register</a></li>
-    </ul>
-</nav>
+<header class="bg-highlight text-button-text">
+    <div class="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
+        <h1 class="text-2xl font-bold">Parkman</h1>
+        <nav class="space-x-4">
+            <a href="/" class="hover:text-tertiary">Domů</a>
+            <a href="/register" class="hover:text-tertiary">Registrace</a>
+        </nav>
+    </div>
+</header>


### PR DESCRIPTION
## Summary
- remove duplicate header from the landing page
- turn `NavMenu` into a full header with title and links

## Testing
- `dotnet test` *(fails: .NET 9 SDK not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687e241b59b88326a1dd567d40b31b1f