### PR TITLE
Add Blazor login page

### DIFF
--- a/Parkman.Frontend/Pages/Login.razor
+++ b/Parkman.Frontend/Pages/Login.razor
@@ -1,0 +1,73 @@
+@page "/login"
+@using System.Net.Http.Json
+@using System.ComponentModel.DataAnnotations
+
+<div class="container mx-auto p-4">
+    <h3 class="text-2xl font-bold mb-4 text-center text-headline">Login</h3>
+
+    <EditForm Model="_model" OnValidSubmit="HandleLogin" class="max-w-md mx-auto bg-main p-6 rounded-xl shadow-md">
+        <DataAnnotationsValidator />
+        <ValidationSummary />
+        <div class="mb-4">
+            <label class="block text-sm font-medium text-headline">
+                <i class="fas fa-envelope mr-1"></i>
+                Email
+            </label>
+            <InputText @bind-Value="_model.Email" class="mt-1 block w-full rounded-md border border-stroke shadow-sm focus-visible:ring-2 focus-visible:ring-highlight focus:outline-none" />
+            <ValidationMessage For="@(() => _model.Email)" class="text-red-500 text-sm mt-1" />
+        </div>
+        <div class="mb-6">
+            <label class="block text-sm font-medium text-headline">
+                <i class="fas fa-lock mr-1"></i>
+                Password
+            </label>
+            <div class="flex items-center">
+                <InputText @bind-Value="_model.Password" type="@(showPassword ? "text" : "password")" class="mt-1 block w-full rounded-md border border-stroke shadow-sm focus-visible:ring-2 focus-visible:ring-highlight focus:outline-none" />
+                <button type="button" class="ml-2 text-sm text-paragraph" @onclick="() => showPassword = !showPassword">@(showPassword ? "Hide" : "Show")</button>
+            </div>
+            <ValidationMessage For="@(() => _model.Password)" class="text-red-500 text-sm mt-1" />
+        </div>
+        <button type="submit" class="w-full bg-highlight text-white font-semibold py-2 px-4 rounded-lg shadow-md hover:bg-tertiary transition duration-200 disabled:opacity-50" disabled="@isSubmitting">
+            @(isSubmitting ? "Logging in..." : "Login")
+        </button>
+        @if (errorMessage != null)
+        {
+            <p class="text-red-600 text-center mt-4">@errorMessage</p>
+        }
+    </EditForm>
+</div>
+
+@code {
+    private LoginFormModel _model = new();
+    private bool showPassword;
+    private bool isSubmitting;
+    private string? errorMessage;
+
+    [Inject] private HttpClient Http { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
+
+    private async Task HandleLogin()
+    {
+        isSubmitting = true;
+        errorMessage = null;
+        var response = await Http.PostAsJsonAsync("api/auth/login", _model);
+        if (response.IsSuccessStatusCode)
+        {
+            Navigation.NavigateTo("/");
+        }
+        else
+        {
+            errorMessage = "Invalid email or password.";
+        }
+        isSubmitting = false;
+    }
+
+    public class LoginFormModel
+    {
+        [Required, EmailAddress]
+        public string Email { get; set; } = string.Empty;
+
+        [Required]
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/Parkman.Frontend/Shared/NavMenu.razor
+++ b/Parkman.Frontend/Shared/NavMenu.razor
@@ -4,6 +4,7 @@
         <nav class="space-x-4">
             <a href="/" class="hover:text-tertiary">Domů</a>
             <a href="/register" class="hover:text-tertiary">Registrace</a>
+            <a href="/login" class="hover:text-tertiary">Login</a>
         </nav>
     </div>
 </header>


### PR DESCRIPTION
## Summary
- implement `Login.razor` with email/password form
- link login page from navigation menu

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687e283f3fc48326a219117f0b3fc9a1