### PR TITLE
Fix ValidationSummary ambiguity

### DIFF
--- a/Parkman.Frontend/Pages/Login.razor
+++ b/Parkman.Frontend/Pages/Login.razor
@@ -1,13 +1,14 @@
 @page "/login"
 @using System.Net.Http.Json
 @using System.ComponentModel.DataAnnotations
+@using Forms = Microsoft.AspNetCore.Components.Forms
 
 <div class="container mx-auto p-4">
     <h3 class="text-2xl font-bold mb-4 text-center text-headline">Login</h3>
 
     <EditForm Model="_model" OnValidSubmit="HandleLogin" class="max-w-md mx-auto bg-main p-6 rounded-xl shadow-md grid gap-4">
         <DataAnnotationsValidator />
-        <ValidationSummary />
+        <Forms.ValidationSummary />
         <div class="grid gap-1">
             <label class="block text-sm font-medium text-headline">
                 <i class="fas fa-envelope mr-1"></i>

--- a/Parkman.Frontend/Pages/Register.razor
+++ b/Parkman.Frontend/Pages/Register.razor
@@ -2,6 +2,7 @@
 @using System.Net.Http.Json
 @using System.ComponentModel.DataAnnotations
 @using Blazorise
+@using Forms = Microsoft.AspNetCore.Components.Forms
 
 <Div Margin="Margin.IsAuto.OnX" Width="Width.Is75">
 
@@ -21,7 +22,7 @@
 {
     <EditForm Model="_companyModel" OnValidSubmit="RegisterCompany" class="max-w-3xl mx-auto bg-main p-6 rounded-xl shadow-md grid gap-4">
         <DataAnnotationsValidator />
-        <ValidationSummary />
+        <Forms.ValidationSummary />
 
         <h4 class="text-xl font-semibold mt-6 mb-4 text-headline border-b border-muted pb-1">Account Information</h4>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -187,7 +188,7 @@ else
 {
     <EditForm Model="_model" OnValidSubmit="RegisterUser" class="max-w-3xl mx-auto bg-main p-6 rounded-xl shadow-md grid gap-4">
         <DataAnnotationsValidator />
-        <ValidationSummary />
+        <Forms.ValidationSummary />
 
     <!-- Úèetní údaje -->
     <h4 class="text-xl font-semibold mt-6 mb-4 text-headline border-b border-muted pb-1">Account Information</h4>


### PR DESCRIPTION
## Summary
- disambiguate ValidationSummary component by aliasing the built-in forms namespace

## Testing
- `dotnet build Parkman.sln -c Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687e3aad7f1c8326a5b8dced12b85cc9