### PR TITLE
Fix conditional Razor class attributes

### DIFF
--- a/Parkman.Frontend/Pages/Register.razor
+++ b/Parkman.Frontend/Pages/Register.razor
@@ -19,7 +19,7 @@
 
 @if (registerAsCompany)
 {
-    <EditForm Model="_companyModel" OnValidSubmit="RegisterCompany" class="card p-4 mx-auto form-section @(registerAsCompany ? "show" : null)" style="max-width: 768px;">
+    <EditForm Model="_companyModel" OnValidSubmit="RegisterCompany" class="@($"card p-4 mx-auto form-section {(registerAsCompany ? "show" : "")}")" style="max-width: 768px;">
         <DataAnnotationsValidator />
         <Forms.ValidationSummary />
 
@@ -168,7 +168,7 @@
 }
 else
 {
-    <EditForm Model="_model" OnValidSubmit="RegisterUser" class="card p-4 mx-auto form-section @(registerAsCompany ? null : "show")" style="max-width: 768px;">
+    <EditForm Model="_model" OnValidSubmit="RegisterUser" class="@($"card p-4 mx-auto form-section {(registerAsCompany ? "" : "show")}")" style="max-width: 768px;">
         <DataAnnotationsValidator />
         <Forms.ValidationSummary />
 


### PR DESCRIPTION
## Summary
- fix Razor parsing error by putting conditional classes into single C# expression

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e4f1a24ac8326bdf734def30edb0a