### PR TITLE
Replace FontAwesome icons with Bootstrap

### DIFF
--- a/Parkman.Frontend/Pages/Index.razor
+++ b/Parkman.Frontend/Pages/Index.razor
@@ -13,7 +13,7 @@
         <div class="col-md-4 mb-3">
             <div class="card h-100">
                 <div class="card-body">
-                    <i class="fas fa-calendar-check fa-2xl text-primary mb-3"></i>
+                    <i class="bi bi-calendar-check fs-1 text-primary mb-3"></i>
                     <h3 class="h5">Rychlá rezervace</h3>
                     <p>Rezervujte si parkovací místo během několika vteřin.</p>
                 </div>
@@ -22,7 +22,7 @@
         <div class="col-md-4 mb-3">
             <div class="card h-100">
                 <div class="card-body">
-                    <i class="fas fa-map-marker-alt fa-2xl text-primary mb-3"></i>
+                    <i class="bi bi-geo-alt fs-1 text-primary mb-3"></i>
                     <h3 class="h5">Přehledná mapa</h3>
                     <p>Snadno najděte nejbližší dostupné parkoviště.</p>
                 </div>
@@ -31,7 +31,7 @@
         <div class="col-md-4 mb-3">
             <div class="card h-100">
                 <div class="card-body">
-                    <i class="fas fa-shield-alt fa-2xl text-primary mb-3"></i>
+                    <i class="bi bi-shield-check fs-1 text-primary mb-3"></i>
                     <h3 class="h5">Bezpečná platba</h3>
                     <p>Vaše platby jsou chráněny moderními technologiemi.</p>
                 </div>

--- a/Parkman.Frontend/Pages/Login.razor
+++ b/Parkman.Frontend/Pages/Login.razor
@@ -11,7 +11,7 @@
         <Forms.ValidationSummary />
         <div class="mb-3">
             <label class="form-label">
-                <i class="fas fa-envelope me-1"></i>
+                <i class="bi bi-envelope me-1"></i>
                 Email
             </label>
             <InputText @bind-Value="_model.Email" class="form-control" />
@@ -19,7 +19,7 @@
         </div>
         <div class="mb-3">
             <label class="form-label">
-                <i class="fas fa-lock me-1"></i>
+                <i class="bi bi-lock me-1"></i>
                 Password
             </label>
             <div class="input-group">

--- a/Parkman.Frontend/Parkman.Frontend.csproj
+++ b/Parkman.Frontend/Parkman.Frontend.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Blazorise" Version="1.8.0" />
     <PackageReference Include="Blazorise.Bootstrap" Version="1.8.0" />
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.8.0" />
+    <PackageReference Include="Blazorise.Icons.Bootstrap" Version="1.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.7" PrivateAssets="all" />
   </ItemGroup>

--- a/Parkman.Frontend/Program.cs
+++ b/Parkman.Frontend/Program.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
 using Blazorise;
 using Blazorise.Bootstrap;
-using Blazorise.Icons.FontAwesome;
+using Blazorise.Icons.Bootstrap;
 
 namespace Parkman.Frontend;
 
@@ -21,7 +21,7 @@ public class Program
         builder.Services
             .AddBlazorise(options => { options.Immediate = true; })
             .AddBootstrapProviders()
-            .AddFontAwesomeIcons();
+            .AddBootstrapIcons();
 
         builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 

--- a/Parkman.Frontend/wwwroot/index.html
+++ b/Parkman.Frontend/wwwroot/index.html
@@ -7,9 +7,9 @@
     <base href="/" />
     <link href="_content/Blazorise/blazorise.css" rel="stylesheet" />
     <link href="_content/Blazorise.Bootstrap/blazorise.bootstrap.css" rel="stylesheet" />
-    <link href="_content/Blazorise.Icons.FontAwesome/blazorise.icons.fontawesome.css" rel="stylesheet" />
+    <link href="_content/Blazorise.Icons.Bootstrap/blazorise.icons.bootstrap.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-pI0fCJ+9IiVbGi99Z+eK6Ff8gDuwZQzQ0jrOqRCGDpa2BkLomPvKgJo0vvVuv5QW0HQwZ0kniNXhEtQx5lBw5g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link href="css/register.css" rel="stylesheet" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- switch to Blazorise Bootstrap icons
- update icon imports in Program and index.html
- replace FA icon markup on the Index and Login pages

## Testing
- `dotnet test` *(fails: NETSDK1045, .NET 9.0 SDK not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687e535ab51883268b4e6c30c9d32d7f