### PR TITLE
Fix registration API base address

### DIFF
--- a/Parkman.Frontend/Program.cs
+++ b/Parkman.Frontend/Program.cs
@@ -23,7 +23,8 @@ public class Program
             .AddBootstrapProviders()
             .AddBootstrapIcons();
 
-        builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+        var apiBaseAddress = builder.Configuration["ApiBaseAddress"] ?? builder.HostEnvironment.BaseAddress;
+        builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(apiBaseAddress) });
 
         await builder.Build().RunAsync();
     }

--- a/Parkman.Frontend/wwwroot/appsettings.json
+++ b/Parkman.Frontend/wwwroot/appsettings.json
@@ -1,0 +1,3 @@
+{
+  "ApiBaseAddress": "https://localhost:7152/"
+}


### PR DESCRIPTION
## Summary
- configure `HttpClient` base address from `ApiBaseAddress` setting
- add `appsettings.json` with the default API URL

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e954d3dfc8326ab5e3e25b8d9f02c