### PR TITLE
Add dashboard page

### DIFF
--- a/Parkman.Frontend/Pages/Dashboard.razor
+++ b/Parkman.Frontend/Pages/Dashboard.razor
@@ -1,0 +1,76 @@
+@page "/dashboard"
+@using System.Net.Http.Json
+
+<h3 class="mb-4">Dashboard</h3>
+
+<div class="mb-3">
+    <h5>User Profile</h5>
+    @if (profile == null)
+    {
+        <p>Loading profile...</p>
+    }
+    else
+    {
+        <div class="card p-3">
+            <p><strong>Email:</strong> @profile.Email</p>
+            <p><strong>Name:</strong> @profile.FirstName @profile.LastName</p>
+        </div>
+    }
+</div>
+
+<div>
+    <h5>Your Reservations</h5>
+    @if (reservations == null)
+    {
+        <p>Loading reservations...</p>
+    }
+    else if (!reservations.Any())
+    {
+        <p>No reservations yet.</p>
+    }
+    else
+    {
+        <ul class="list-group mb-3">
+            @foreach (var r in reservations)
+            {
+                <li class="list-group-item">
+                    <span>@r.StartTime.ToString("g") - @r.EndTime.ToString("g")</span>
+                </li>
+            }
+        </ul>
+    }
+    <button class="btn btn-primary" @onclick="CreateReservation">Create Reservation</button>
+</div>
+
+@code {
+    private UserProfile? profile;
+    private List<ReservationDto>? reservations;
+
+    [Inject] private HttpClient Http { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        profile = await Http.GetFromJsonAsync<UserProfile>("api/profile");
+        reservations = await Http.GetFromJsonAsync<List<ReservationDto>>("api/reservations");
+    }
+
+    private async Task CreateReservation()
+    {
+        // Placeholder call
+        await Http.PostAsync("api/reservations", null);
+        reservations = await Http.GetFromJsonAsync<List<ReservationDto>>("api/reservations");
+    }
+
+    private class UserProfile
+    {
+        public string Email { get; set; } = string.Empty;
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+    }
+
+    private class ReservationDto
+    {
+        public DateTime StartTime { get; set; }
+        public DateTime EndTime { get; set; }
+    }
+}

--- a/Parkman.Frontend/Pages/Login.razor
+++ b/Parkman.Frontend/Pages/Login.razor
@@ -54,7 +54,7 @@
         var response = await Http.PostAsJsonAsync("api/auth/login", _model);
         if (response.IsSuccessStatusCode)
         {
-            Navigation.NavigateTo("/");
+            Navigation.NavigateTo("/dashboard");
         }
         else
         {

--- a/Parkman.Frontend/Shared/NavMenu.razor
+++ b/Parkman.Frontend/Shared/NavMenu.razor
@@ -19,6 +19,11 @@
                 <!-- Pravá strana -->
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
                     <li class="nav-item">
+                        <a class="nav-link" href="/dashboard">
+                            <i class="bi bi-speedometer2 me-1"></i>Dashboard
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" href="/register">
                             <i class="bi bi-person-plus-fill me-1"></i>Registrace
                         </a>

--- a/Parkman/Controllers/ReservationsController.cs
+++ b/Parkman/Controllers/ReservationsController.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+
+namespace Parkman.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class ReservationsController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get() => Ok(Array.Empty<object>());
+
+    [HttpPost]
+    public IActionResult Create() => Ok();
+}

--- a/Parkman/Controllers/UserController.cs
+++ b/Parkman/Controllers/UserController.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Parkman.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class UserController : ControllerBase
+{
+    [HttpGet("profile")]
+    public IActionResult GetProfile()
+    {
+        // Return minimal profile info from authenticated user
+        var email = User.Identity?.Name ?? "unknown";
+        return Ok(new { Email = email, FirstName = "", LastName = "" });
+    }
+}


### PR DESCRIPTION
## Summary
- add a dashboard page showing profile and reservations
- add stub user and reservation API controllers
- link dashboard in navigation menu
- redirect login page to dashboard

## Testing
- `dotnet test Parkman.sln` *(fails: current .NET SDK doesn't support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687e97d0b55c8326b6c96cb5f19deb95