### PR TITLE
Restrict dashboard access

### DIFF
--- a/Parkman.Frontend/App.razor
+++ b/Parkman.Frontend/App.razor
@@ -1,10 +1,12 @@
-<Router AppAssembly="@typeof(Program).Assembly">
-    <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
-    </Found>
-    <NotFound>
-        <LayoutView Layout="@typeof(MainLayout)">
-            <p>Sorry, there's nothing at this address.</p>
-        </LayoutView>
-    </NotFound>
-</Router>
+<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(Program).Assembly">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+        </Found>
+        <NotFound>
+            <LayoutView Layout="@typeof(MainLayout)">
+                <p>Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>

--- a/Parkman.Frontend/Pages/Dashboard.razor
+++ b/Parkman.Frontend/Pages/Dashboard.razor
@@ -1,5 +1,7 @@
 @page "/dashboard"
 @using System.Net.Http.Json
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
 
 <h3 class="mb-4">Dashboard</h3>
 

--- a/Parkman.Frontend/Pages/Login.razor
+++ b/Parkman.Frontend/Pages/Login.razor
@@ -2,6 +2,7 @@
 @using System.Net.Http.Json
 @using System.ComponentModel.DataAnnotations
 @using Blazorise
+@using Parkman.Frontend.Services
 
 <div class="container py-4">
     <h3 class="text-center mb-4 h4">Login</h3>
@@ -44,15 +45,15 @@
     private bool isSubmitting;
     private string? errorMessage;
 
-    [Inject] private HttpClient Http { get; set; } = default!;
+    [Inject] private AuthService Auth { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
 
     private async Task HandleLogin()
     {
         isSubmitting = true;
         errorMessage = null;
-        var response = await Http.PostAsJsonAsync("api/auth/login", _model);
-        if (response.IsSuccessStatusCode)
+        var success = await Auth.Login(_model.Email, _model.Password);
+        if (success)
         {
             Navigation.NavigateTo("/dashboard");
         }

--- a/Parkman.Frontend/Program.cs
+++ b/Parkman.Frontend/Program.cs
@@ -3,6 +3,8 @@ using System.Net.Http;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Components.Authorization;
+using Parkman.Frontend.Services;
 using System.Threading.Tasks;
 using Blazorise;
 using Blazorise.Bootstrap;
@@ -22,6 +24,11 @@ public class Program
             .AddBlazorise(options => { options.Immediate = true; })
             .AddBootstrapProviders()
             .AddBootstrapIcons();
+
+        builder.Services.AddAuthorizationCore();
+        builder.Services.AddScoped<ApiAuthenticationStateProvider>();
+        builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<ApiAuthenticationStateProvider>());
+        builder.Services.AddScoped<AuthService>();
 
         var apiBaseAddress = builder.Configuration["ApiBaseAddress"] ?? builder.HostEnvironment.BaseAddress;
         builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(apiBaseAddress) });

--- a/Parkman.Frontend/Services/ApiAuthenticationStateProvider.cs
+++ b/Parkman.Frontend/Services/ApiAuthenticationStateProvider.cs
@@ -1,0 +1,38 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace Parkman.Frontend.Services;
+
+public class ApiAuthenticationStateProvider : AuthenticationStateProvider
+{
+    private readonly HttpClient _http;
+
+    public ApiAuthenticationStateProvider(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        try
+        {
+            var profile = await _http.GetFromJsonAsync<ProfileDto>("api/user/profile");
+            var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, profile.Email) }, "serverAuth");
+            return new AuthenticationState(new ClaimsPrincipal(identity));
+        }
+        catch
+        {
+            return new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity()));
+        }
+    }
+
+    public void NotifyAuthenticationStateChanged() => NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
+
+    private class ProfileDto
+    {
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/Parkman.Frontend/Services/AuthService.cs
+++ b/Parkman.Frontend/Services/AuthService.cs
@@ -1,0 +1,37 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace Parkman.Frontend.Services;
+
+public class AuthService
+{
+    private readonly HttpClient _http;
+    private readonly ApiAuthenticationStateProvider _authStateProvider;
+
+    public AuthService(HttpClient http, ApiAuthenticationStateProvider authStateProvider)
+    {
+        _http = http;
+        _authStateProvider = authStateProvider;
+    }
+
+    public async Task<bool> Login(string email, string password)
+    {
+        var response = await _http.PostAsJsonAsync("api/auth/login", new { Email = email, Password = password });
+        if (response.IsSuccessStatusCode)
+        {
+            _authStateProvider.NotifyAuthenticationStateChanged();
+            return true;
+        }
+        return false;
+    }
+
+    public async Task Logout()
+    {
+        var response = await _http.PostAsync("api/auth/logout", null);
+        if (response.IsSuccessStatusCode)
+        {
+            _authStateProvider.NotifyAuthenticationStateChanged();
+        }
+    }
+}

--- a/Parkman.Frontend/Shared/NavMenu.razor
+++ b/Parkman.Frontend/Shared/NavMenu.razor
@@ -1,3 +1,6 @@
+@using Microsoft.AspNetCore.Components.Authorization
+@using Parkman.Frontend.Services
+@implements IDisposable
 <header>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
         <div class="container-fluid">
@@ -18,23 +21,65 @@
 
                 <!-- Pravá strana -->
                 <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-                    <li class="nav-item">
-                        <a class="nav-link" href="/dashboard">
-                            <i class="bi bi-speedometer2 me-1"></i>Dashboard
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/register">
-                            <i class="bi bi-person-plus-fill me-1"></i>Registrace
-                        </a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/login">
-                            <i class="bi bi-box-arrow-in-right me-1"></i>Přihlášení
-                        </a>
-                    </li>
+                    @if (isLoggedIn)
+                    {
+                        <li class="nav-item">
+                            <a class="nav-link" href="/dashboard">
+                                <i class="bi bi-speedometer2 me-1"></i>Dashboard
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="" @onclick="Logout">
+                                <i class="bi bi-box-arrow-right me-1"></i>Logout
+                            </a>
+                        </li>
+                    }
+                    else
+                    {
+                        <li class="nav-item">
+                            <a class="nav-link" href="/register">
+                                <i class="bi bi-person-plus-fill me-1"></i>Registrace
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="/login">
+                                <i class="bi bi-box-arrow-in-right me-1"></i>Přihlášení
+                            </a>
+                        </li>
+                    }
                 </ul>
             </div>
         </div>
     </nav>
 </header>
+
+@code {
+    [Inject] private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
+    [Inject] private AuthService Auth { get; set; } = default!;
+
+    private bool isLoggedIn;
+
+    protected override async Task OnInitializedAsync()
+    {
+        AuthenticationStateProvider.AuthenticationStateChanged += AuthStateChanged;
+        var state = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        isLoggedIn = state.User.Identity?.IsAuthenticated ?? false;
+    }
+
+    private async void AuthStateChanged(Task<AuthenticationState> task)
+    {
+        var state = await task;
+        isLoggedIn = state.User.Identity?.IsAuthenticated ?? false;
+        StateHasChanged();
+    }
+
+    private async Task Logout()
+    {
+        await Auth.Logout();
+    }
+
+    public void Dispose()
+    {
+        AuthenticationStateProvider.AuthenticationStateChanged -= AuthStateChanged;
+    }
+}

--- a/Parkman.Frontend/_Imports.razor
+++ b/Parkman.Frontend/_Imports.razor
@@ -7,3 +7,4 @@
 @using Parkman.Frontend
 @using Parkman.Frontend.Shared
 @using Blazorise
+@using Microsoft.AspNetCore.Components.Authorization

--- a/Parkman/Controllers/AuthController.cs
+++ b/Parkman/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using Parkman.Domain.Entities;
 using Parkman.Models;
 
@@ -50,5 +51,13 @@ public class AuthController : ControllerBase
             return Ok();
         }
         return Unauthorized();
+    }
+
+    [Authorize]
+    [HttpPost("logout")]
+    public async Task<IActionResult> Logout()
+    {
+        await _signInManager.SignOutAsync();
+        return Ok();
     }
 }


### PR DESCRIPTION
## Summary
- make dashboard page authorized only
- add auth services and state provider
- adjust app setup to use authentication state
- toggle nav links based on login state
- add logout endpoint on server

## Testing
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_687e9e6f8b908326bbfc836a866ebcc3