### PR TITLE
Add lockout configuration and handling

### DIFF
--- a/Parkman/Controllers/AuthController.cs
+++ b/Parkman/Controllers/AuthController.cs
@@ -112,11 +112,23 @@ public class AuthController : ControllerBase
         if(!ModelState.IsValid)
             return ValidationProblem(ModelState);
 
-        var result = await _signInManager.PasswordSignInAsync(request.Email, request.Password, false, false);
-        if(result.Succeeded)
+        var result = await _signInManager.PasswordSignInAsync(request.Email, request.Password, false, lockoutOnFailure: true);
+
+        if (result.Succeeded)
         {
             return Ok();
         }
+
+        if (result.IsLockedOut)
+        {
+            return Forbid();
+        }
+
+        if (result.IsNotAllowed)
+        {
+            return StatusCode(StatusCodes.Status403Forbidden);
+        }
+
         return Unauthorized();
     }
 

--- a/Parkman/Program.cs
+++ b/Parkman/Program.cs
@@ -12,7 +12,13 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
-builder.Services.AddIdentity<ApplicationUser, IdentityRole>()
+builder.Services
+    .AddIdentity<ApplicationUser, IdentityRole>(options =>
+    {
+        options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(5);
+        options.Lockout.MaxFailedAccessAttempts = 5;
+        options.Lockout.AllowedForNewUsers = true;
+    })
     .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddDefaultTokenProviders();
 


### PR DESCRIPTION
## Summary
- configure lockout settings for Identity
- handle lockout results in `AuthController.Login`

## Testing
- `dotnet test` *(fails: .NET 9.0 SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f5e215ecc83268a66fe3abc38cb65