### PR TITLE
Use stored user profile details

### DIFF
--- a/Parkman/Controllers/UserController.cs
+++ b/Parkman/Controllers/UserController.cs
@@ -1,5 +1,9 @@
+using System;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Parkman.Domain.Entities;
+using Parkman.Infrastructure.Repositories.Entities;
 
 namespace Parkman.Controllers;
 
@@ -8,11 +12,54 @@ namespace Parkman.Controllers;
 [Authorize]
 public class UserController : ControllerBase
 {
-    [HttpGet("profile")]
-    public IActionResult GetProfile()
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IPersonProfileRepository _personProfileRepository;
+    private readonly ICompanyProfileRepository _companyProfileRepository;
+
+    public UserController(
+        UserManager<ApplicationUser> userManager,
+        IPersonProfileRepository personProfileRepository,
+        ICompanyProfileRepository companyProfileRepository)
     {
-        // Return minimal profile info from authenticated user
-        var email = User.Identity?.Name ?? "unknown";
-        return Ok(new { Email = email, FirstName = "", LastName = "" });
+        _userManager = userManager;
+        _personProfileRepository = personProfileRepository;
+        _companyProfileRepository = companyProfileRepository;
+    }
+
+    [HttpGet("profile")]
+    public async Task<IActionResult> GetProfile()
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null)
+        {
+            return Unauthorized();
+        }
+
+        var email = user.Email ?? user.UserName ?? "unknown";
+
+        string firstName = string.Empty;
+        string lastName = string.Empty;
+
+        if (user.PersonProfile != null)
+        {
+            var profile = await _personProfileRepository.GetByIdAsync(user.Id);
+            if (profile != null)
+            {
+                firstName = profile.FirstName;
+                lastName = profile.LastName;
+            }
+        }
+        else if (user.CompanyProfile != null)
+        {
+            var profile = await _companyProfileRepository.GetByIdAsync(user.Id);
+            if (profile != null)
+            {
+                var parts = profile.ContactPersonName.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+                firstName = parts.Length > 0 ? parts[0] : profile.ContactPersonName;
+                lastName = parts.Length > 1 ? parts[1] : string.Empty;
+            }
+        }
+
+        return Ok(new { Email = email, FirstName = firstName, LastName = lastName });
     }
 }


### PR DESCRIPTION
## Summary
- wire up user profile retrieval with UserManager and repositories
- pull first and last name from PersonProfile or CompanyProfile

## Testing
- `dotnet test Parkman.Tests/Parkman.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687f63d721688326b88d39337c83fc4e