### PR TITLE
Fix HttpClient credentials for Blazor WASM

### DIFF
--- a/Parkman.Frontend/Parkman.Frontend.csproj
+++ b/Parkman.Frontend/Parkman.Frontend.csproj
@@ -10,6 +10,5 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.7" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.HttpHandler" Version="3.2.1" />
   </ItemGroup>
 </Project>

--- a/Parkman.Frontend/Program.cs
+++ b/Parkman.Frontend/Program.cs
@@ -32,20 +32,17 @@ public class Program
         builder.Services.AddScoped<AuthService>();
 
         var apiBaseAddress = builder.Configuration["ApiBaseAddress"] ?? builder.HostEnvironment.BaseAddress;
+        builder.Services.AddScoped<IncludeCredentialsHandler>();
         builder.Services.AddScoped(sp =>
         {
-            var handler = new HttpClientHandler
+            var handler = new IncludeCredentialsHandler
             {
-                UseCookies = true
+                InnerHandler = new HttpClientHandler
+                {
+                    UseCookies = true
+                }
             };
 
-            var browserHandler = new WebAssemblyHttpHandler
-            {
-                Credentials = FetchCredentials.Include
-                
-            };
-
-            handler.InnerHandler = browserHandler;
             return new HttpClient(handler) { BaseAddress = new Uri(apiBaseAddress) };
         });
 

--- a/Parkman.Frontend/Services/IncludeCredentialsHandler.cs
+++ b/Parkman.Frontend/Services/IncludeCredentialsHandler.cs
@@ -1,0 +1,15 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.WebAssembly.Http;
+
+namespace Parkman.Frontend.Services;
+
+public class IncludeCredentialsHandler : DelegatingHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        request.SetBrowserRequestCredentials(BrowserRequestCredentials.Include);
+        return base.SendAsync(request, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- configure `HttpClient` to include credentials for each request
- add custom delegating handler for browser credentials
- remove obsolete WebAssembly HttpHandler package

## Testing
- `dotnet test` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687f670b1db48326b042c7c1be608b62