### PR TITLE
Fix HttpClient handler cookie settings

### DIFF
--- a/Parkman.Frontend/Program.cs
+++ b/Parkman.Frontend/Program.cs
@@ -37,10 +37,7 @@ public class Program
         {
             var handler = new IncludeCredentialsHandler
             {
-                InnerHandler = new HttpClientHandler
-                {
-                    UseCookies = true
-                }
+                InnerHandler = new HttpClientHandler()
             };
 
             return new HttpClient(handler) { BaseAddress = new Uri(apiBaseAddress) };


### PR DESCRIPTION
## Summary
- remove explicit `UseCookies = true` from `HttpClientHandler`
- keep `IncludeCredentialsHandler` with a plain `HttpClientHandler` inner handler

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6b5038b083268ac373ff3e736f11