### PR TITLE
Allow credentials in CORS

### DIFF
--- a/Parkman/Program.cs
+++ b/Parkman/Program.cs
@@ -35,7 +35,8 @@ builder.Services.AddCors(options =>
     {
         policy.WithOrigins("https://localhost:13883")
             .AllowAnyHeader()
-            .AllowAnyMethod();
+            .AllowAnyMethod()
+            .AllowCredentials();
     });
 });
 


### PR DESCRIPTION
## Summary
- update backend CORS policy to allow credentials

## Testing
- `dotnet test Parkman.Tests/Parkman.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687f6b550fbc8326afe9b9920d6d75d4