### PR TITLE
Fix missing extension namespace

### DIFF
--- a/Parkman.Frontend/_Imports.razor
+++ b/Parkman.Frontend/_Imports.razor
@@ -9,3 +9,4 @@
 @using Blazorise
 @using Microsoft.AspNetCore.Components.Authorization
 @using Parkman.Frontend.Models
+@using Parkman.Frontend.Services


### PR DESCRIPTION
## Summary
- add `Parkman.Frontend.Services` to frontend imports so extension methods resolve

## Testing
- `dotnet test Parkman.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687f7301590083269dba018b3cf9f404