### PR TITLE
Add repository transaction support

### DIFF
--- a/Parkman/Infrastructure/Repositories/GenericRepository.cs
+++ b/Parkman/Infrastructure/Repositories/GenericRepository.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Parkman.Infrastructure.Repositories
 {
@@ -133,6 +134,11 @@ namespace Parkman.Infrastructure.Repositories
             }
             _dbSet.Remove(entity);
             await _context.SaveChangesAsync();
+        }
+
+        public Task<IDbContextTransaction> BeginTransactionAsync()
+        {
+            return _context.Database.BeginTransactionAsync();
         }
 
         private static IQueryable<TEntity> ApplySearch(IQueryable<TEntity> query, string search)

--- a/Parkman/Infrastructure/Repositories/IGenericRepository.cs
+++ b/Parkman/Infrastructure/Repositories/IGenericRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Parkman.Infrastructure.Repositories
 {
@@ -29,5 +30,6 @@ namespace Parkman.Infrastructure.Repositories
         Task<TEntity> AddAsync(TEntity entity);
         Task UpdateAsync(TEntity entity);
         Task DeleteAsync(TEntity entity);
+        Task<IDbContextTransaction> BeginTransactionAsync();
     }
 }

--- a/Parkman/Infrastructure/Services/UserCompanyRegistrationService.cs
+++ b/Parkman/Infrastructure/Services/UserCompanyRegistrationService.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Identity;
 using Parkman.Domain.Entities;
 using Parkman.Domain.Enums;
 using Parkman.Infrastructure.Repositories.Entities;
-using Parkman.Infrastructure;
 
 namespace Parkman.Infrastructure.Services;
 
@@ -30,18 +29,15 @@ public class UserCompanyRegistrationService : IUserCompanyRegistrationService
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly ICompanyProfileRepository _companyRepo;
     private readonly IVehicleRepository _vehicleRepo;
-    private readonly ApplicationDbContext _context;
 
     public UserCompanyRegistrationService(
         UserManager<ApplicationUser> userManager,
         ICompanyProfileRepository companyRepo,
-        IVehicleRepository vehicleRepo,
-        ApplicationDbContext context)
+        IVehicleRepository vehicleRepo)
     {
         _userManager = userManager;
         _companyRepo = companyRepo;
         _vehicleRepo = vehicleRepo;
-        _context = context;
     }
 
     public async Task<IdentityResult> RegisterAsync(
@@ -60,7 +56,7 @@ public class UserCompanyRegistrationService : IUserCompanyRegistrationService
         VehiclePropulsionType propulsionType,
         bool shareable = false)
     {
-        using var transaction = await _context.Database.BeginTransactionAsync();
+        using var transaction = await _companyRepo.BeginTransactionAsync();
 
         var user = new ApplicationUser { UserName = email, Email = email };
         var createResult = await _userManager.CreateAsync(user, password);

--- a/Parkman/Infrastructure/Services/UserVehicleRegistrationService.cs
+++ b/Parkman/Infrastructure/Services/UserVehicleRegistrationService.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Identity;
 using Parkman.Domain.Entities;
 using Parkman.Domain.Enums;
 using Parkman.Infrastructure.Repositories.Entities;
-using Parkman.Infrastructure;
 
 namespace Parkman.Infrastructure.Services;
 
@@ -28,18 +27,15 @@ public class UserVehicleRegistrationService : IUserVehicleRegistrationService
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IPersonProfileRepository _personRepo;
     private readonly IVehicleRepository _vehicleRepo;
-    private readonly ApplicationDbContext _context;
 
     public UserVehicleRegistrationService(
         UserManager<ApplicationUser> userManager,
         IPersonProfileRepository personRepo,
-        IVehicleRepository vehicleRepo,
-        ApplicationDbContext context)
+        IVehicleRepository vehicleRepo)
     {
         _userManager = userManager;
         _personRepo = personRepo;
         _vehicleRepo = vehicleRepo;
-        _context = context;
     }
 
     public async Task<IdentityResult> RegisterAsync(
@@ -56,7 +52,7 @@ public class UserVehicleRegistrationService : IUserVehicleRegistrationService
         VehiclePropulsionType propulsionType,
         bool shareable = false)
     {
-        using var transaction = await _context.Database.BeginTransactionAsync();
+        using var transaction = await _personRepo.BeginTransactionAsync();
 
         var user = new ApplicationUser { UserName = email, Email = email };
         var createResult = await _userManager.CreateAsync(user, password);


### PR DESCRIPTION
## Summary
- add `BeginTransactionAsync` to `IGenericRepository`
- implement the transaction method in `GenericRepository`
- use new method in user registration services
- remove direct `ApplicationDbContext` usage

## Testing
- `dotnet test` *(fails: NETSDK1045 - .NET 9.0 target not supported by installed SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6881e2a3136c8326a3dc5470dc2ff5ab