### PR TITLE
Implement optional pairing code for company registration

### DIFF
--- a/Parkman.Frontend/Pages/Register.razor
+++ b/Parkman.Frontend/Pages/Register.razor
@@ -261,11 +261,6 @@
                         </InputSelect>
                         <ValidationMessage For="@(() => _companyModel.PropulsionType)" class="text-danger small mt-1" />
                     </div>
-                    <div class="col-md-6">
-                        <label class="form-label">Pairing Password</label>
-                        <InputText @bind-Value="_companyModel.PairingPassword" class="form-control" />
-                        <ValidationMessage For="@(() => _companyModel.PairingPassword)" class="text-danger small mt-1" />
-                    </div>
                 </div>
 
                 <div class="form-check mb-3">

--- a/Parkman.Shared/Models/RegisterCompanyRequest.cs
+++ b/Parkman.Shared/Models/RegisterCompanyRequest.cs
@@ -47,6 +47,4 @@ public class RegisterCompanyRequest
     public VehiclePropulsionType PropulsionType { get; set; }
 
     public bool Shareable { get; set; }
-
-    public string? PairingPassword { get; set; }
 }

--- a/Parkman/Controllers/AuthController.cs
+++ b/Parkman/Controllers/AuthController.cs
@@ -94,8 +94,7 @@ public class AuthController : ControllerBase
             request.Brand,
             request.Type,
             request.PropulsionType,
-            request.Shareable,
-            request.PairingPassword);
+            request.Shareable);
 
         if(!result.Succeeded)
         {


### PR DESCRIPTION
## Summary
- drop `PairingPassword` from `RegisterCompanyRequest`
- remove pairing password input from the company registration UI
- adjust API controller to omit the parameter when registering a company

## Testing
- `dotnet build Parkman.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68820605baa88326bda57c9701e083d9