### PR TITLE
Load user profile details in controllers

### DIFF
--- a/Parkman/Controllers/CompanyController.cs
+++ b/Parkman/Controllers/CompanyController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Parkman.Shared.Entities;
 using Parkman.Infrastructure.Repositories.Entities;
 
@@ -25,7 +26,10 @@ public class CompanyController : ControllerBase
     [HttpPost("approve/{personUserId}")]
     public async Task<IActionResult> ApproveMember(string personUserId)
     {
-        var user = await _userManager.GetUserAsync(User);
+        var userId = _userManager.GetUserId(User);
+        var user = await _userManager.Users
+            .Include(u => u.CompanyProfile)
+            .FirstOrDefaultAsync(u => u.Id == userId);
         if (user?.CompanyProfile == null)
             return Forbid();
 


### PR DESCRIPTION
## Summary
- ensure EF navigation properties for profiles are loaded in `UserController`
- load company profile in `CompanyController`

## Testing
- `dotnet test Parkman.sln -v minimal` *(fails: NETSDK1045, current SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68828c77a85883269977f8ec369644a5