### PR TITLE
Fix cross-site login

### DIFF
--- a/Parkman/Program.cs
+++ b/Parkman/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Http;
 using Parkman.Shared.Entities;
 using Parkman.Infrastructure;
 using Parkman.Infrastructure.Repositories;
@@ -33,6 +34,12 @@ builder.Services
     })
     .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddDefaultTokenProviders();
+
+builder.Services.ConfigureApplicationCookie(options =>
+{
+    options.Cookie.SameSite = SameSiteMode.None;
+    options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+});
 
 builder.Services.AddCors(options =>
 {


### PR DESCRIPTION
## Summary
- allow cookies in cross-site requests for login by configuring SameSite and SecurePolicy

## Testing
- `dotnet test Parkman.sln` *(fails: current .NET SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68831fcffcd88326beed840675201414