### PR TITLE
Fix failing test namespace

### DIFF
--- a/Parkman.Tests/Domain/ParkingSpotTests.cs
+++ b/Parkman.Tests/Domain/ParkingSpotTests.cs
@@ -1,5 +1,5 @@
 using System;
-using Parkman.Shared.Entities;
+using Parkman.Domain.Entities;
 using Parkman.Shared.Enums;
 using Xunit;
 


### PR DESCRIPTION
## Summary
- correct outdated namespace in `ParkingSpotTests`

## Testing
- `dotnet test Parkman.sln`

------
https://chatgpt.com/codex/tasks/task_e_688346c6e64483269b92528028d87c9a