### PR TITLE
Fix EF Core in-memory transaction warnings in tests

### DIFF
--- a/Parkman.Tests/Infrastructure/UserCompanyRegistrationServiceTests.cs
+++ b/Parkman.Tests/Infrastructure/UserCompanyRegistrationServiceTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -38,6 +39,7 @@ public class UserCompanyRegistrationServiceTests
     {
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
             .Options;
 
         using var context = new ApplicationDbContext(options);

--- a/Parkman.Tests/Infrastructure/UserVehicleRegistrationServiceTests.cs
+++ b/Parkman.Tests/Infrastructure/UserVehicleRegistrationServiceTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -38,6 +39,7 @@ public class UserVehicleRegistrationServiceTests
     {
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
             .Options;
 
         using var context = new ApplicationDbContext(options);
@@ -71,6 +73,7 @@ public class UserVehicleRegistrationServiceTests
     {
         var options = new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(x => x.Ignore(InMemoryEventId.TransactionIgnoredWarning))
             .Options;
 
         using var context = new ApplicationDbContext(options);


### PR DESCRIPTION
## Summary
- ignore EF Core `TransactionIgnoredWarning` in tests using the in-memory provider
- update `UserVehicleRegistrationServiceTests` and `UserCompanyRegistrationServiceTests`

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688359a3b9748326a5dbd89c0e0ffec2