### PR TITLE
Add admin parking management

### DIFF
--- a/Parkman.Frontend/Pages/ManageParking.razor
+++ b/Parkman.Frontend/Pages/ManageParking.razor
@@ -1,0 +1,91 @@
+@page "/manage-parking"
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize(Roles="Administrator")]
+
+<h3 class="mb-4">Manage Parking</h3>
+
+<EditForm Model="lot" OnValidSubmit="CreateLot" class="card p-3 mb-3" Style="max-width:600px">
+    <DataAnnotationsValidator />
+    <div class="mb-3">
+        <label class="form-label">Name</label>
+        <InputText class="form-control" @bind-Value="lot.Name" />
+        <ValidationMessage For="@(() => lot.Name)" class="text-danger small mt-1" />
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Address</label>
+        <InputText class="form-control" @bind-Value="lot.Address" />
+        <ValidationMessage For="@(() => lot.Address)" class="text-danger small mt-1" />
+    </div>
+
+    <h5>Parking Spots</h5>
+    @foreach (var spot in lot.Spots)
+    {
+        <div class="border rounded p-2 mb-2">
+            <div class="mb-2">
+                <label class="form-label">Label</label>
+                <InputText class="form-control" @bind-Value="spot.Label" />
+            </div>
+            <div class="mb-2">
+                <label class="form-label">Type</label>
+                <InputSelect class="form-select" @bind-Value="spot.Type">
+                    @foreach (var v in Enum.GetValues<ParkingSpotType>())
+                    {
+                        <option value="@v">@v</option>
+                    }
+                </InputSelect>
+            </div>
+            <div class="mb-2">
+                <label class="form-label">Accessibility</label>
+                <InputSelect class="form-select" @bind-Value="spot.Accessibility">
+                    @foreach (var v in Enum.GetValues<ParkingSpotAccessibility>())
+                    {
+                        <option value="@v">@v</option>
+                    }
+                </InputSelect>
+            </div>
+            <div class="mb-2">
+                <label class="form-label">Allowed Propulsion</label>
+                <InputSelect class="form-select" @bind-Value="spot.AllowedPropulsion">
+                    @foreach (var v in Enum.GetValues<ParkingSpotAllowedPropulsionType>())
+                    {
+                        <option value="@v">@v</option>
+                    }
+                </InputSelect>
+            </div>
+        </div>
+    }
+    <button type="button" class="btn btn-secondary me-2" @onclick="AddSpot">Add Spot</button>
+    <button type="submit" class="btn btn-primary" disabled="@isSubmitting">Create Lot</button>
+</EditForm>
+
+@if (success)
+{
+    <div class="alert alert-success">Created successfully.</div>
+}
+
+@code {
+    private CreateParkingLotRequest lot = new();
+    private bool isSubmitting;
+    private bool success;
+
+    [Inject] private HttpClient Http { get; set; } = default!;
+
+    private void AddSpot()
+    {
+        lot.Spots.Add(new CreateParkingSpotRequest());
+    }
+
+    private async Task CreateLot()
+    {
+        isSubmitting = true;
+        success = false;
+        var response = await Http.PostAsJsonAsync("api/admin/parking/lots", lot);
+        if (response.IsSuccessStatusCode)
+        {
+            success = true;
+            lot = new CreateParkingLotRequest();
+        }
+        isSubmitting = false;
+    }
+}

--- a/Parkman.Frontend/Shared/NavMenu.razor
+++ b/Parkman.Frontend/Shared/NavMenu.razor
@@ -30,6 +30,11 @@
                                 <i class="bi bi-speedometer2 me-1"></i>Dashboard
                             </a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="/manage-parking">
+                                <i class="bi bi-tools me-1"></i>Admin
+                            </a>
+                        </li>
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" href="#" id="profileDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 <i class="bi bi-person-circle me-1"></i>

--- a/Parkman.Shared/Models/CreateParkingLotRequest.cs
+++ b/Parkman.Shared/Models/CreateParkingLotRequest.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Parkman.Shared.Models;
+
+public class CreateParkingLotRequest
+{
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public string Address { get; set; } = string.Empty;
+
+    public List<CreateParkingSpotRequest> Spots { get; set; } = new();
+}

--- a/Parkman.Shared/Models/CreateParkingSpotRequest.cs
+++ b/Parkman.Shared/Models/CreateParkingSpotRequest.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+using Parkman.Shared.Enums;
+
+namespace Parkman.Shared.Models;
+
+public class CreateParkingSpotRequest
+{
+    [Required]
+    public string Label { get; set; } = string.Empty;
+
+    [Required]
+    public ParkingSpotType Type { get; set; }
+
+    [Required]
+    public ParkingSpotAccessibility Accessibility { get; set; }
+
+    [Required]
+    public ParkingSpotAllowedPropulsionType AllowedPropulsion { get; set; }
+}

--- a/Parkman/Controllers/AdminParkingController.cs
+++ b/Parkman/Controllers/AdminParkingController.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Parkman.Domain.Entities;
+using Parkman.Infrastructure.Services.Entities;
+using Parkman.Shared.Models;
+using System.Linq;
+
+namespace Parkman.Controllers;
+
+[ApiController]
+[Route("api/admin/parking")]
+[Authorize(Roles = "Administrator")]
+public class AdminParkingController : ControllerBase
+{
+    private readonly IParkingLotService _lotService;
+    private readonly IParkingSpotService _spotService;
+
+    public AdminParkingController(IParkingLotService lotService, IParkingSpotService spotService)
+    {
+        _lotService = lotService;
+        _spotService = spotService;
+    }
+
+    [HttpPost("lots")]
+    public async Task<IActionResult> CreateLot(CreateParkingLotRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var lot = new ParkingLot(request.Name, request.Address);
+        foreach (var spotRequest in request.Spots)
+        {
+            var spot = new ParkingSpot(spotRequest.Label, spotRequest.Type, spotRequest.Accessibility, spotRequest.AllowedPropulsion);
+            lot.AddSpot(spot);
+        }
+
+        await _lotService.AddAsync(lot);
+        return CreatedAtAction(nameof(GetLot), new { id = lot.Id }, new { lot.Id });
+    }
+
+    [HttpGet("lots/{id}")]
+    public async Task<IActionResult> GetLot(int id)
+    {
+        var lot = await _lotService.GetByIdAsync(id);
+        if (lot == null) return NotFound();
+
+        var result = new
+        {
+            lot.Id,
+            lot.Name,
+            lot.Address,
+            Spots = lot.Spots.Select(s => new
+            {
+                s.Id,
+                s.Label,
+                s.Type,
+                s.Accessibility,
+                s.AllowedPropulsion
+            })
+        };
+        return Ok(result);
+    }
+
+    [HttpPost("lots/{lotId}/spots")]
+    public async Task<IActionResult> AddSpot(int lotId, CreateParkingSpotRequest request)
+    {
+        if (!ModelState.IsValid)
+            return ValidationProblem(ModelState);
+
+        var lot = await _lotService.GetByIdAsync(lotId);
+        if (lot == null) return NotFound();
+
+        var spot = new ParkingSpot(request.Label, request.Type, request.Accessibility, request.AllowedPropulsion);
+        lot.AddSpot(spot);
+        await _spotService.AddAsync(spot);
+        return CreatedAtAction(nameof(GetLot), new { id = lotId }, new { spot.Id });
+    }
+}


### PR DESCRIPTION
## Summary
- allow administrators to manage parking lots and parking spots
- create API controller for admin parking management
- support creating parking lots and parking spots via new request models
- add simple admin UI in the frontend with a new Manage Parking page
- show admin link in the navigation menu

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688360907a188326b54ef485e1aa624b