### PR TITLE
Add available parking spot lookup

### DIFF
--- a/Parkman.Tests/Infrastructure/ParkingSpotRepositoryTests.cs
+++ b/Parkman.Tests/Infrastructure/ParkingSpotRepositoryTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Parkman.Domain.Entities;
+using Parkman.Infrastructure;
+using Parkman.Infrastructure.Repositories.Entities;
+using Parkman.Shared.Enums;
+using Xunit;
+
+namespace Parkman.Tests.Infrastructure;
+
+public class ParkingSpotRepositoryTests
+{
+    [Fact]
+    public async Task ListAvailableAsync_returns_only_free_spots()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        int busySpotId;
+        int freeSpotId;
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var lot = new ParkingLot("Lot1", "Addr1");
+            var busy = new ParkingSpot("1", ParkingSpotType.Regular, ParkingSpotAccessibility.None, ParkingSpotAllowedPropulsionType.Any);
+            var free = new ParkingSpot("2", ParkingSpotType.Regular, ParkingSpotAccessibility.None, ParkingSpotAllowedPropulsionType.Any);
+            lot.AddSpot(busy);
+            lot.AddSpot(free);
+            context.ParkingLots.Add(lot);
+            var reservation = new Reservation(DateTime.Parse("2024-01-01T10:00:00"), DateTime.Parse("2024-01-01T11:00:00"));
+            busy.AddReservation(reservation);
+            context.Reservations.Add(reservation);
+            await context.SaveChangesAsync();
+            busySpotId = busy.Id;
+            freeSpotId = free.Id;
+        }
+
+        using (var context = new ApplicationDbContext(options))
+        {
+            var repo = new ParkingSpotRepository(context, NullLogger<GenericRepository<ParkingSpot>>.Instance);
+            var result = await repo.ListAvailableAsync(DateTime.Parse("2024-01-01T10:30:00"), DateTime.Parse("2024-01-01T11:30:00"));
+
+            Assert.Contains(result, s => s.Id == freeSpotId);
+            Assert.DoesNotContain(result, s => s.Id == busySpotId);
+        }
+    }
+}

--- a/Parkman/Controllers/ReservationsController.cs
+++ b/Parkman/Controllers/ReservationsController.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Parkman.Infrastructure.Services.Entities;
 
 namespace Parkman.Controllers;
 
@@ -9,6 +12,24 @@ namespace Parkman.Controllers;
 [Authorize]
 public class ReservationsController : ControllerBase
 {
+    private readonly IParkingSpotService _spotService;
+
+    public ReservationsController(IParkingSpotService spotService)
+    {
+        _spotService = spotService;
+    }
+
+    [HttpGet("available")]
+    public async Task<IActionResult> GetAvailable(DateTime startTime, DateTime endTime)
+    {
+        if (endTime <= startTime)
+            return BadRequest();
+
+        var spots = await _spotService.ListAvailableAsync(startTime, endTime);
+        var result = spots.Select(s => new { s.Id, s.Label, Lot = s.ParkingLot.Name });
+        return Ok(result);
+    }
+
     [HttpGet]
     public IActionResult Get() => Ok(Array.Empty<object>());
 

--- a/Parkman/Infrastructure/Repositories/Entities/IParkingSpotRepository.cs
+++ b/Parkman/Infrastructure/Repositories/Entities/IParkingSpotRepository.cs
@@ -2,5 +2,8 @@ using Parkman.Domain.Entities;
 
 namespace Parkman.Infrastructure.Repositories.Entities;
 
-public interface IParkingSpotRepository : IGenericRepository<ParkingSpot> { }
+public interface IParkingSpotRepository : IGenericRepository<ParkingSpot>
+{
+    Task<IReadOnlyList<ParkingSpot>> ListAvailableAsync(DateTime startTime, DateTime endTime);
+}
 

--- a/Parkman/Infrastructure/Repositories/Entities/ParkingSpotRepository.cs
+++ b/Parkman/Infrastructure/Repositories/Entities/ParkingSpotRepository.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore;
 using Parkman.Domain.Entities;
 
 namespace Parkman.Infrastructure.Repositories.Entities;
@@ -9,4 +10,12 @@ public class ParkingSpotRepository : GenericRepository<ParkingSpot>, IParkingSpo
         ApplicationDbContext context,
         ILogger<GenericRepository<ParkingSpot>> logger)
         : base(context, logger) { }
+
+    public async Task<IReadOnlyList<ParkingSpot>> ListAvailableAsync(DateTime startTime, DateTime endTime)
+    {
+        return await DbSet
+            .Include(s => s.ParkingLot)
+            .Where(s => !s.Reservations.Any(r => r.StartTime < endTime && startTime < r.EndTime))
+            .ToListAsync();
+    }
 }

--- a/Parkman/Infrastructure/Services/Entities/IParkingSpotService.cs
+++ b/Parkman/Infrastructure/Services/Entities/IParkingSpotService.cs
@@ -3,5 +3,8 @@ using Parkman.Domain.Entities;
 
 namespace Parkman.Infrastructure.Services.Entities;
 
-public interface IParkingSpotService : IGenericService<ParkingSpot> { }
+public interface IParkingSpotService : IGenericService<ParkingSpot>
+{
+    Task<IReadOnlyList<ParkingSpot>> ListAvailableAsync(DateTime startTime, DateTime endTime);
+}
 

--- a/Parkman/Infrastructure/Services/Entities/ParkingSpotService.cs
+++ b/Parkman/Infrastructure/Services/Entities/ParkingSpotService.cs
@@ -5,5 +5,15 @@ namespace Parkman.Infrastructure.Services.Entities;
 
 public class ParkingSpotService : GenericService<ParkingSpot>, IParkingSpotService
 {
-    public ParkingSpotService(IParkingSpotRepository repository) : base(repository) { }
+    private readonly IParkingSpotRepository _repository;
+
+    public ParkingSpotService(IParkingSpotRepository repository) : base(repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<IReadOnlyList<ParkingSpot>> ListAvailableAsync(DateTime startTime, DateTime endTime)
+    {
+        return _repository.ListAvailableAsync(startTime, endTime);
+    }
 }


### PR DESCRIPTION
## Summary
- add `ListAvailableAsync` to repositories and services
- implement `ReservationsController.GetAvailable` endpoint
- test parking spot availability logic

## Testing
- `dotnet test Parkman.sln -v minimal` *(fails: NETSDK1045: current SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68837bad0514832691414f42bd628940