### PR TITLE
Fix API launch settings

### DIFF
--- a/Parkman/Program.cs
+++ b/Parkman/Program.cs
@@ -47,7 +47,7 @@ builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
     {
-        policy.WithOrigins("https://localhost:13883")
+        policy.WithOrigins("https://localhost:13883", "http://localhost:13883")
             .AllowAnyHeader()
             .AllowAnyMethod()
             .AllowCredentials();

--- a/Parkman/Properties/launchSettings.json
+++ b/Parkman/Properties/launchSettings.json
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:7152;http://localhost:5154",
+      "applicationUrl": "https://localhost:7152;http://localhost:5154",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
## Summary
- allow HTTP or HTTPS for CORS
- ensure API launch profile uses HTTPS for port 7152

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b02c49bc8326872214befced0e6d