### PR TITLE
Improve server error handling and frontend error pages

### DIFF
--- a/Parkman.Frontend/Pages/ConfirmEmail.razor
+++ b/Parkman.Frontend/Pages/ConfirmEmail.razor
@@ -19,7 +19,16 @@
         if (query.TryGetValue("userId", out var userId) && query.TryGetValue("token", out var token))
         {
             var url = $"api/auth/confirm?userId={Uri.EscapeDataString(userId)}&token={Uri.EscapeDataString(token)}";
-            var response = await Http.GetAsync(url);
+            HttpResponseMessage response;
+            try
+            {
+                response = await Http.GetAsync(url);
+            }
+            catch (HttpRequestException)
+            {
+                Navigation.NavigateTo("/error?message=Unable%20to%20reach%20the%20server.");
+                return;
+            }
             message = response.IsSuccessStatusCode ? "Email confirmed." : "Confirmation failed.";
         }
         else

--- a/Parkman.Frontend/Pages/Dashboard.razor
+++ b/Parkman.Frontend/Pages/Dashboard.razor
@@ -58,18 +58,32 @@
     private List<ReservationDto>? reservations;
 
     [Inject] private HttpClient Http { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
     {
-        profile = await Http.GetFromJsonAsync<UserProfileDto>("api/user/profile");
-        reservations = await Http.GetFromJsonAsync<List<ReservationDto>>("api/reservations");
+        try
+        {
+            profile = await Http.GetFromJsonAsync<UserProfileDto>("api/user/profile");
+            reservations = await Http.GetFromJsonAsync<List<ReservationDto>>("api/reservations");
+        }
+        catch (HttpRequestException)
+        {
+            Navigation.NavigateTo("/error?message=Unable%20to%20reach%20the%20server.");
+        }
     }
 
     private async Task CreateReservation()
     {
-        // Placeholder call
-        await Http.PostAsync("api/reservations", null);
-        reservations = await Http.GetFromJsonAsync<List<ReservationDto>>("api/reservations");
+        try
+        {
+            await Http.PostAsync("api/reservations", null);
+            reservations = await Http.GetFromJsonAsync<List<ReservationDto>>("api/reservations");
+        }
+        catch (HttpRequestException)
+        {
+            Navigation.NavigateTo("/error?message=Unable%20to%20reach%20the%20server.");
+        }
     }
 
 }

--- a/Parkman.Frontend/Pages/Error.razor
+++ b/Parkman.Frontend/Pages/Error.razor
@@ -1,0 +1,12 @@
+@page "/error"
+@using Microsoft.AspNetCore.WebUtilities
+
+@code {
+    [Parameter] [SupplyParameterFromQuery] public string? message { get; set; }
+}
+
+<div class="container py-5 text-center">
+    <h3 class="text-danger">An error occurred</h3>
+    <p>@(string.IsNullOrWhiteSpace(message) ? "An unexpected error occurred." : message)</p>
+    <a class="btn btn-primary" href="/">Back to Home</a>
+</div>

--- a/Parkman.Frontend/Pages/ForgotPassword.razor
+++ b/Parkman.Frontend/Pages/ForgotPassword.razor
@@ -33,6 +33,7 @@
     private string? message;
 
     [Inject] private HttpClient Http { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
 
     protected override void OnInitialized()
     {
@@ -43,7 +44,18 @@
     {
         isSubmitting = true;
         message = null;
-        var response = await Http.PostAsJsonAsync("api/auth/forgot-password", _model);
+        HttpResponseMessage response;
+        try
+        {
+            response = await Http.PostAsJsonAsync("api/auth/forgot-password", _model);
+        }
+        catch (HttpRequestException)
+        {
+            Navigation.NavigateTo("/error?message=Unable%20to%20reach%20the%20server.");
+            isSubmitting = false;
+            return;
+        }
+
         if (response.IsSuccessStatusCode)
         {
             message = "If an account with that email exists, a reset link was sent.";

--- a/Parkman.Frontend/Pages/ManageParking.razor
+++ b/Parkman.Frontend/Pages/ManageParking.razor
@@ -70,6 +70,7 @@
     private bool success;
 
     [Inject] private HttpClient Http { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
 
     private void AddSpot()
     {
@@ -80,7 +81,18 @@
     {
         isSubmitting = true;
         success = false;
-        var response = await Http.PostAsJsonAsync("api/admin/parking/lots", lot);
+        HttpResponseMessage response;
+        try
+        {
+            response = await Http.PostAsJsonAsync("api/admin/parking/lots", lot);
+        }
+        catch (HttpRequestException)
+        {
+            Navigation.NavigateTo("/error?message=Unable%20to%20reach%20the%20server.");
+            isSubmitting = false;
+            return;
+        }
+
         if (response.IsSuccessStatusCode)
         {
             success = true;

--- a/Parkman.Frontend/Pages/Register.razor
+++ b/Parkman.Frontend/Pages/Register.razor
@@ -396,6 +396,7 @@
     private readonly VehiclePropulsionType[] VehiclePropulsionTypes = Enum.GetValues<VehiclePropulsionType>();
 
     [Inject] private HttpClient Http { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
 
     protected override void OnInitialized()
     {
@@ -434,7 +435,17 @@
             }
         }
 
-        var response = await Http.PostAsJsonAsync("api/auth/register", _model);
+        HttpResponseMessage response;
+        try
+        {
+            response = await Http.PostAsJsonAsync("api/auth/register", _model);
+        }
+        catch (HttpRequestException)
+        {
+            Navigation.NavigateTo("/error?message=Unable%20to%20reach%20the%20server.");
+            isSubmitting = false;
+            return;
+        }
         var error = await response.ApplyValidationErrorsAsync(_userEditContext, _userMessageStore);
 
         if (error is null)
@@ -455,7 +466,17 @@
         isSubmitting = true;
         successMessage = null;
 
-        var response = await Http.PostAsJsonAsync("api/auth/register/company", _companyModel);
+        HttpResponseMessage response;
+        try
+        {
+            response = await Http.PostAsJsonAsync("api/auth/register/company", _companyModel);
+        }
+        catch (HttpRequestException)
+        {
+            Navigation.NavigateTo("/error?message=Unable%20to%20reach%20the%20server.");
+            isSubmitting = false;
+            return;
+        }
         var error = await response.ApplyValidationErrorsAsync(_companyEditContext, _companyMessageStore);
 
         if (error is null)

--- a/Parkman.Frontend/Pages/ResetPassword.razor
+++ b/Parkman.Frontend/Pages/ResetPassword.razor
@@ -59,7 +59,18 @@
     {
         isSubmitting = true;
         message = null;
-        var response = await Http.PostAsJsonAsync("api/auth/reset-password", _model);
+        HttpResponseMessage response;
+        try
+        {
+            response = await Http.PostAsJsonAsync("api/auth/reset-password", _model);
+        }
+        catch (HttpRequestException)
+        {
+            Navigation.NavigateTo("/error?message=Unable%20to%20reach%20the%20server.");
+            isSubmitting = false;
+            return;
+        }
+
         if (response.IsSuccessStatusCode)
         {
             message = "Password reset successful.";

--- a/Parkman.Frontend/Services/AuthService.cs
+++ b/Parkman.Frontend/Services/AuthService.cs
@@ -18,7 +18,16 @@ public class AuthService
 
     public async Task<(bool Success, string? Error)> Login(string email, string password)
     {
-        var response = await _http.PostAsJsonAsync("api/auth/login", new { Email = email, Password = password });
+        HttpResponseMessage response;
+        try
+        {
+            response = await _http.PostAsJsonAsync("api/auth/login", new { Email = email, Password = password });
+        }
+        catch (HttpRequestException)
+        {
+            return (false, "Unable to reach the server.");
+        }
+
         if (response.IsSuccessStatusCode)
         {
             _authStateProvider.NotifyAuthenticationStateChanged();
@@ -48,10 +57,17 @@ public class AuthService
 
     public async Task Logout()
     {
-        var response = await _http.PostAsync("api/auth/logout", null);
-        if (response.IsSuccessStatusCode)
+        try
         {
-            _authStateProvider.NotifyAuthenticationStateChanged();
+            var response = await _http.PostAsync("api/auth/logout", null);
+            if (response.IsSuccessStatusCode)
+            {
+                _authStateProvider.NotifyAuthenticationStateChanged();
+            }
+        }
+        catch (HttpRequestException)
+        {
+            // ignore when server is unreachable
         }
     }
 }

--- a/Parkman.Frontend/Shared/NavMenu.razor
+++ b/Parkman.Frontend/Shared/NavMenu.razor
@@ -80,6 +80,7 @@
     [Inject] private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
     [Inject] private AuthService Auth { get; set; } = default!;
     [Inject] private HttpClient Http { get; set; } = default!;
+    [Inject] private NavigationManager Navigation { get; set; } = default!;
 
     private bool isLoggedIn;
     private ProfileDto? profile;
@@ -121,8 +122,9 @@
         {
             profile = await Http.GetFromJsonAsync<ProfileDto>("api/user/profile");
         }
-        catch
+        catch (HttpRequestException)
         {
+            Navigation.NavigateTo("/error?message=Unable%20to%20reach%20the%20server.");
             profile = null;
         }
     }

--- a/Parkman.Frontend/_Imports.razor
+++ b/Parkman.Frontend/_Imports.razor
@@ -6,6 +6,7 @@
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Components
 @using Microsoft.JSInterop
 @using Parkman.Shared.Dtos
 @using Parkman.Frontend

--- a/Parkman/Controllers/ErrorController.cs
+++ b/Parkman/Controllers/ErrorController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Parkman.Controllers;
+
+[ApiController]
+public class ErrorController : ControllerBase
+{
+    [Route("error")]
+    public IActionResult HandleError()
+    {
+        var feature = HttpContext.Features.Get<IExceptionHandlerPathFeature>();
+        var problem = new ProblemDetails
+        {
+            Title = "An unexpected error occurred.",
+            Detail = feature?.Error.Message,
+            Status = StatusCodes.Status500InternalServerError
+        };
+        return StatusCode(problem.Status ?? 500, problem);
+    }
+}

--- a/Parkman/Program.cs
+++ b/Parkman/Program.cs
@@ -77,6 +77,9 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+app.UseExceptionHandler("/error");
+app.UseStatusCodePages();
+
 app.UseHttpsRedirection();
 
 app.UseCors();


### PR DESCRIPTION
## Summary
- add an API `ErrorController` with an `/error` endpoint
- configure middleware to use the error endpoint
- add an `Error` page to the Blazor frontend
- catch `HttpRequestException` in frontend services and pages to show the new page
- import `Microsoft.AspNetCore.Components` in `_Imports.razor`

## Testing
- `dotnet test Parkman.sln --no-build -v normal` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6883de1891388326ae65b0cd45c91961