### PR TITLE
Fix locked-out response in AuthController

### DIFF
--- a/Parkman/Controllers/AuthController.cs
+++ b/Parkman/Controllers/AuthController.cs
@@ -146,7 +146,7 @@ public class AuthController : ControllerBase
 
         if (result.IsLockedOut)
         {
-            return Forbid(new ProblemDetails { Title = "Account is locked." });
+            return StatusCode(StatusCodes.Status403Forbidden, new ProblemDetails { Title = "Account is locked." });
         }
 
         if (result.IsNotAllowed)


### PR DESCRIPTION
## Summary
- return `ProblemDetails` with 403 instead of calling `Forbid`

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6883e072e3d08326a06685b080d4c982