### PR TITLE
Add JWT cookie auth

### DIFF
--- a/Parkman/Parkman.csproj
+++ b/Parkman/Parkman.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Parkman/appsettings.Development.json
+++ b/Parkman/appsettings.Development.json
@@ -7,5 +7,10 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Jwt": {
+    "Issuer": "Parkman",
+    "Audience": "Parkman",
+    "Key": "supersecretkey1234567890"
   }
 }

--- a/Parkman/appsettings.json
+++ b/Parkman/appsettings.json
@@ -8,5 +8,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Jwt": {
+    "Issuer": "Parkman",
+    "Audience": "Parkman",
+    "Key": "supersecretkey1234567890"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- add JWT bearer package
- configure JWT authentication and read tokens from `access_token` cookie
- generate JWT cookie on login and remove cookie on logout
- store issuer, audience and key in settings

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883e78d681c83268da577a2bf461a79