### PR TITLE
Improve auth form validation

### DIFF
--- a/Parkman.Shared/Models/LoginRequest.cs
+++ b/Parkman.Shared/Models/LoginRequest.cs
@@ -4,9 +4,10 @@ namespace Parkman.Shared.Models;
 
 public class LoginRequest
 {
-    [Required, EmailAddress]
+    [Required(ErrorMessage = "Email is required."), EmailAddress(ErrorMessage = "Invalid email address.")]
     public string Email { get; set; } = string.Empty;
 
-    [Required]
+    [Required(ErrorMessage = "Password is required."),
+     StringLength(100, MinimumLength = 6, ErrorMessage = "Password must be at least 6 characters long.")]
     public string Password { get; set; } = string.Empty;
 }

--- a/Parkman.Shared/Models/RegisterCompanyRequest.cs
+++ b/Parkman.Shared/Models/RegisterCompanyRequest.cs
@@ -5,45 +5,50 @@ namespace Parkman.Shared.Models;
 
 public class RegisterCompanyRequest
 {
-    [Required, EmailAddress]
+    [Required(ErrorMessage = "Email is required."), EmailAddress(ErrorMessage = "Invalid email address.")]
     public string Email { get; set; } = string.Empty;
 
-    [Required, StringLength(100, MinimumLength = 6)]
+    [Required(ErrorMessage = "Password is required."),
+     StringLength(100, MinimumLength = 6, ErrorMessage = "Password must be at least 6 characters long."),
+     RegularExpression(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\da-zA-Z]).{6,}$",
+        ErrorMessage = "Password must contain uppercase, lowercase, number and special character.")]
     public string Password { get; set; } = string.Empty;
 
-    [Required, Compare(nameof(Password)), StringLength(100, MinimumLength = 6)]
+    [Required(ErrorMessage = "Please confirm password."),
+     Compare(nameof(Password), ErrorMessage = "Passwords do not match."),
+     StringLength(100, MinimumLength = 6, ErrorMessage = "Password must be at least 6 characters long.")]
     public string ConfirmPassword { get; set; } = string.Empty;
 
-    [Required, StringLength(100)]
+    [Required(ErrorMessage = "Company name is required."), StringLength(100)]
     public string CompanyName { get; set; } = string.Empty;
 
-    [Required, RegularExpression(@"^\d{8}$", ErrorMessage = "IČO must have 8 digits.")]
+    [Required(ErrorMessage = "IČO is required."), RegularExpression(@"^\d{8}$", ErrorMessage = "IČO must have 8 digits.")]
     public string Ico { get; set; } = string.Empty;
 
     public string Dic { get; set; } = string.Empty;
 
-    [Required, StringLength(100)]
+    [Required(ErrorMessage = "Contact person name is required."), StringLength(100)]
     public string ContactPersonName { get; set; } = string.Empty;
 
-    [Required, EmailAddress]
+    [Required(ErrorMessage = "Contact email is required."), EmailAddress(ErrorMessage = "Invalid email address.")]
     public string ContactEmail { get; set; } = string.Empty;
 
-    [Required, Phone]
+    [Required(ErrorMessage = "Phone number is required."), Phone(ErrorMessage = "Invalid phone number.")]
     public string PhoneNumber { get; set; } = string.Empty;
 
-    [Required, StringLength(200)]
+    [Required(ErrorMessage = "Billing address is required."), StringLength(200)]
     public string BillingAddress { get; set; } = string.Empty;
 
-    [Required]
+    [Required(ErrorMessage = "License plate is required.")]
     public string LicensePlate { get; set; } = string.Empty;
 
-    [Required]
+    [Required(ErrorMessage = "Vehicle brand is required.")]
     public VehicleBrand Brand { get; set; }
 
-    [Required]
+    [Required(ErrorMessage = "Vehicle type is required.")]
     public VehicleType Type { get; set; }
 
-    [Required]
+    [Required(ErrorMessage = "Propulsion type is required.")]
     public VehiclePropulsionType PropulsionType { get; set; }
 
     public bool Shareable { get; set; }

--- a/Parkman.Shared/Models/RegisterWithVehicleRequest.cs
+++ b/Parkman.Shared/Models/RegisterWithVehicleRequest.cs
@@ -5,40 +5,45 @@ namespace Parkman.Shared.Models;
 
 public class RegisterWithVehicleRequest
 {
-    [Required, EmailAddress]
+    [Required(ErrorMessage = "Email is required."), EmailAddress(ErrorMessage = "Invalid email address.")]
     public string Email { get; set; } = string.Empty;
 
-    [Required, StringLength(100, MinimumLength = 6)]
+    [Required(ErrorMessage = "Password is required."),
+     StringLength(100, MinimumLength = 6, ErrorMessage = "Password must be at least 6 characters long."),
+     RegularExpression(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\da-zA-Z]).{6,}$",
+        ErrorMessage = "Password must contain uppercase, lowercase, number and special character.")]
     public string Password { get; set; } = string.Empty;
 
-    [Required, Compare(nameof(Password)), StringLength(100, MinimumLength = 6)]
+    [Required(ErrorMessage = "Please confirm password."),
+     Compare(nameof(Password), ErrorMessage = "Passwords do not match."),
+     StringLength(100, MinimumLength = 6, ErrorMessage = "Password must be at least 6 characters long.")]
     public string ConfirmPassword { get; set; } = string.Empty;
 
-    [Required, StringLength(50)]
+    [Required(ErrorMessage = "First name is required."), StringLength(50)]
     public string FirstName { get; set; } = string.Empty;
 
-    [Required, StringLength(50)]
+    [Required(ErrorMessage = "Last name is required."), StringLength(50)]
     public string LastName { get; set; } = string.Empty;
 
-    [Required]
+    [Required(ErrorMessage = "Date of birth is required.")]
     public DateOnly? DateOfBirth { get; set; }
 
-    [Required, Phone]
+    [Required(ErrorMessage = "Phone number is required."), Phone(ErrorMessage = "Invalid phone number.")]
     public string PhoneNumber { get; set; } = string.Empty;
 
-    [Required]
+    [Required(ErrorMessage = "Address is required.")]
     public string Address { get; set; } = string.Empty;
 
-    [Required]
+    [Required(ErrorMessage = "License plate is required.")]
     public string LicensePlate { get; set; } = string.Empty;
 
-    [Required]
+    [Required(ErrorMessage = "Vehicle brand is required.")]
     public VehicleBrand Brand { get; set; }
 
-    [Required]
+    [Required(ErrorMessage = "Vehicle type is required.")]
     public VehicleType Type { get; set; }
 
-    [Required]
+    [Required(ErrorMessage = "Propulsion type is required.")]
     public VehiclePropulsionType PropulsionType { get; set; }
 
     public bool Shareable { get; set; }


### PR DESCRIPTION
## Summary
- add specific error messages to registration models
- enforce password complexity and minimal length for registration and login

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688517c25e18832688d4a26ad9440a2a