### PR TITLE
Implement role-based menu and claims

### DIFF
--- a/Parkman.Frontend/Services/ApiAuthenticationStateProvider.cs
+++ b/Parkman.Frontend/Services/ApiAuthenticationStateProvider.cs
@@ -2,6 +2,8 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Components.Authorization;
 
 namespace Parkman.Frontend.Services;
@@ -20,7 +22,12 @@ public class ApiAuthenticationStateProvider : AuthenticationStateProvider
         try
         {
             var profile = await _http.GetFromJsonAsync<ProfileDto>("api/user/profile");
-            var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, profile.Email) }, "serverAuth");
+            var claims = new List<Claim> { new Claim(ClaimTypes.Name, profile.Email) };
+            if (profile.Roles != null)
+            {
+                claims.AddRange(profile.Roles.Select(r => new Claim(ClaimTypes.Role, r)));
+            }
+            var identity = new ClaimsIdentity(claims, "serverAuth");
             return new AuthenticationState(new ClaimsPrincipal(identity));
         }
         catch
@@ -40,5 +47,6 @@ public class ApiAuthenticationStateProvider : AuthenticationStateProvider
         public string? Brand { get; set; }
         public string? VehicleType { get; set; }
         public string? PropulsionType { get; set; }
+        public List<string>? Roles { get; set; }
     }
 }

--- a/Parkman.Frontend/Shared/NavMenu.razor
+++ b/Parkman.Frontend/Shared/NavMenu.razor
@@ -1,4 +1,6 @@
 @using System.Net.Http.Json
+@using System.Collections.Generic
+@using System.Linq
 @using Microsoft.AspNetCore.Components.Authorization
 @using Parkman.Frontend.Services
 @using Parkman.Shared.Enums
@@ -30,11 +32,14 @@
                                 <i class="bi bi-speedometer2 me-1"></i>Dashboard
                             </a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/manage-parking">
-                                <i class="bi bi-tools me-1"></i>Admin
-                            </a>
-                        </li>
+                        @if (isAdmin)
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link" href="/manage-parking">
+                                    <i class="bi bi-tools me-1"></i>Admin
+                                </a>
+                            </li>
+                        }
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" href="#" id="profileDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 <i class="bi bi-person-circle me-1"></i>
@@ -83,6 +88,7 @@
     [Inject] private NavigationManager Navigation { get; set; } = default!;
 
     private bool isLoggedIn;
+    private bool isAdmin;
     private ProfileDto? profile;
 
     protected override async Task OnInitializedAsync()
@@ -90,6 +96,7 @@
         AuthenticationStateProvider.AuthenticationStateChanged += AuthStateChanged;
         var state = await AuthenticationStateProvider.GetAuthenticationStateAsync();
         isLoggedIn = state.User.Identity?.IsAuthenticated ?? false;
+        isAdmin = state.User.IsInRole("Administrator");
         if (isLoggedIn)
         {
             await LoadProfile();
@@ -100,6 +107,7 @@
     {
         var state = await task;
         isLoggedIn = state.User.Identity?.IsAuthenticated ?? false;
+        isAdmin = state.User.IsInRole("Administrator");
         if (isLoggedIn)
         {
             await LoadProfile();
@@ -121,11 +129,13 @@
         try
         {
             profile = await Http.GetFromJsonAsync<ProfileDto>("api/user/profile");
+            isAdmin = profile?.Roles?.Contains("Administrator") ?? false;
         }
         catch (HttpRequestException)
         {
             Navigation.NavigateTo("/error?message=Unable%20to%20reach%20the%20server.");
             profile = null;
+            isAdmin = false;
         }
     }
 
@@ -138,6 +148,7 @@
         public string? Brand { get; set; }
         public string? VehicleType { get; set; }
         public string? PropulsionType { get; set; }
+        public List<string>? Roles { get; set; }
     }
 
     public void Dispose()

--- a/Parkman.Shared/Dtos/UserProfileDto.cs
+++ b/Parkman.Shared/Dtos/UserProfileDto.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Parkman.Shared.Dtos;
 
 public class UserProfileDto
@@ -9,4 +11,5 @@ public class UserProfileDto
     public string? Brand { get; set; }
     public string? VehicleType { get; set; }
     public string? PropulsionType { get; set; }
+    public List<string> Roles { get; set; } = new();
 }

--- a/Parkman/Controllers/UserController.cs
+++ b/Parkman/Controllers/UserController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Parkman.Shared.Enums;
+using Parkman.Shared.Dtos;
 using Parkman.Infrastructure.Repositories.Entities;
 using Parkman.Shared.Models;
 using Parkman.Domain.Entities;
@@ -54,6 +55,7 @@ public class UserController : ControllerBase
         VehicleBrand? brand = null;
         VehicleType? vehicleType = null;
         VehiclePropulsionType? propulsionType = null;
+        var roles = await _userManager.GetRolesAsync(user);
 
         if (user.PersonProfile != null)
         {
@@ -79,7 +81,19 @@ public class UserController : ControllerBase
             }
         }
 
-        return Ok(new { Email = email, FirstName = firstName, LastName = lastName, LicensePlate = licensePlate, Brand = brand, VehicleType = vehicleType, PropulsionType = propulsionType });
+        var dto = new UserProfileDto
+        {
+            Email = email,
+            FirstName = firstName,
+            LastName = lastName,
+            LicensePlate = licensePlate,
+            Brand = brand?.ToString(),
+            VehicleType = vehicleType?.ToString(),
+            PropulsionType = propulsionType?.ToString(),
+            Roles = roles.ToList()
+        };
+
+        return Ok(dto);
     }
 
     [HttpPut("profile")]


### PR DESCRIPTION
## Summary
- return user roles from backend profile endpoint
- expose roles in `UserProfileDto`
- add role claims in `ApiAuthenticationStateProvider`
- display Admin menu item only for administrators

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c841b327483269c8eeb8448cb0c94